### PR TITLE
Refactor Pro trips mock data with unique schedules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,9 @@
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.2.0",
+    "vitest": "^1.4.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/src/components/TourDashboard.tsx
+++ b/src/components/TourDashboard.tsx
@@ -5,7 +5,7 @@ import { Tour, TourTrip } from '../types/pro';
 
 const mockTour: Tour = {
   id: '1',
-  name: 'Comedy World Tour 2025',
+  name: 'Kevin Hart – Australia Comedy Tour',
   description: 'International comedy tour across 15 cities',
   artistName: 'Alex Thompson',
   startDate: '2025-07-01',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -147,9 +147,9 @@ const Index = () => {
     },
     {
       id: '2',
-      title: "Morgan Wallen – North America Tour",
-      location: "Various Cities",
-      dateRange: "Apr 5 - Jun 20, 2025",
+      title: "Morgan Wallen North America Tour",
+      location: "Multi-City Tour",
+      dateRange: "Apr 5 - May 30, 2025",
       category: 'Touring',
       tags: ["Music", "Multi-City Tour"],
       participants: [
@@ -161,9 +161,9 @@ const Index = () => {
     },
     {
       id: '3',
-      title: "Scarlett Knights – AAU Volleyball Tourney",
-      location: "Orlando, FL",
-      dateRange: "Jul 12 - Jul 16, 2025",
+      title: "Scarlet Knights AAU Volleyball Tourney",
+      location: "Multi-State Tournament",
+      dateRange: "Jun 15 - Jun 22, 2025",
       category: 'Sports – Team Trip',
       tags: ["Youth Sports", "Multi-Family"],
       participants: [
@@ -175,8 +175,8 @@ const Index = () => {
     {
       id: '4',
       title: "Los Angeles Dodgers – Playoffs 2025",
-      location: "Various Stadiums",
-      dateRange: "Oct 1 - Oct 30, 2025",
+      location: "Los Angeles & San Francisco",
+      dateRange: "Oct 1 - Oct 15, 2025",
       category: 'Sports – Team Trip',
       tags: ["Pro Sports", "Championship"],
       participants: [
@@ -187,8 +187,8 @@ const Index = () => {
     },
     {
       id: '5',
-      title: "Content House – Passes Retreat",
-      location: "Bahamas",
+      title: "Content House – Creative Retreat",
+      location: "Malibu, CA",
       dateRange: "Aug 15 - Aug 22, 2025",
       category: 'Business Travel',
       tags: ["Influencer", "Retreat", "Team Coordination"],
@@ -213,9 +213,9 @@ const Index = () => {
     },
     {
       id: '7',
-      title: "The Chainsmokers – Vegas Residency 2025",
+      title: "Chainsmokers – Vegas Residency",
       location: "Las Vegas, NV",
-      dateRange: "Jan 1 - Dec 31, 2025",
+      dateRange: "Jan 2025 - Mar 2025",
       category: 'Touring',
       tags: ["DJ", "Residency", "Recurring"],
       participants: [
@@ -227,9 +227,9 @@ const Index = () => {
     },
     {
       id: '8',
-      title: "Esports Team – Valorant Spring Championship",
-      location: "Chicago, IL",
-      dateRange: "May 20 - May 25, 2025",
+      title: "Esports Team Lawrence Spring Championship",
+      location: "Arlington, TX",
+      dateRange: "May 10 - May 15, 2025",
       category: 'Sports – Team Trip',
       tags: ["Esports", "Championship"],
       participants: [

--- a/src/pages/__tests__/ProTripDetail.test.tsx
+++ b/src/pages/__tests__/ProTripDetail.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import ProTripDetail from '../ProTripDetail';
+import { proTripMockData } from '../../data/proTripMockData';
+import { getTripLabels } from '../../utils/tripLabels';
+
+const renderWithRouter = (id: string) => {
+  render(
+    <MemoryRouter initialEntries={[`/tour/pro-${id}`]}>
+      <Routes>
+        <Route path="/tour/pro-:proTripId" element={<ProTripDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('ProTripDetail', () => {
+  Object.keys(proTripMockData).forEach((id) => {
+    const data = proTripMockData[id];
+    const labels = getTripLabels(data.category);
+
+    it(`renders correct title and labels for trip ${id}`, () => {
+      renderWithRouter(id);
+      expect(screen.getByRole('heading', { name: data.title })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: labels.schedule })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: labels.team })).toBeInTheDocument();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add vitest testing setup and sample test for ProTripDetail
- update Index mock data to match pro trip datasets
- refactor TourDashboard title
- map category labels via `getTripLabels`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c8ff0c260832abec0c39e276759ad