### PR TITLE
Fix route order for Pro trips

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,8 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/trip/:tripId" element={<TripDetail />} />
             <Route path="/trip/:tripId/edit-itinerary" element={<ItineraryAssignmentPage />} />
-            <Route path="/tour/:tourId" element={<TourDetail />} />
             <Route path="/tour/pro-:proTripId" element={<ProTripDetail />} />
+            <Route path="/tour/:tourId" element={<TourDetail />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/__tests__/ProTripRouteOrder.test.tsx
+++ b/src/pages/__tests__/ProTripRouteOrder.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProTripDetail from '../ProTripDetail';
+import TourDetail from '../TourDetail';
+
+const renderWithRoutes = (path: string) => {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/tour/pro-:proTripId" element={<ProTripDetail />} />
+        <Route path="/tour/:tourId" element={<TourDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('Route order for pro trips', () => {
+  it('renders ProTripDetail when visiting /tour/pro-1', () => {
+    renderWithRoutes('/tour/pro-1');
+    // title from proTripMockData for id '1'
+    expect(screen.getByRole('heading', { name: 'Kevin Hart – Australia Comedy Tour' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show Pro trip details when path begins with `pro-`
- add regression test for routing precedence

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd02f5f60832aa35d16bbddd8a2ed