### PR TITLE
Add index navigation tests

### DIFF
--- a/src/pages/__tests__/IndexProTripNavigation.test.tsx
+++ b/src/pages/__tests__/IndexProTripNavigation.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Index from '../Index';
+import ProTripDetail from '../ProTripDetail';
+import { proTripMockData } from '../../data/proTripMockData';
+
+const renderWithRouter = () => {
+  render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<Index />} />
+        <Route path="/tour/pro-:proTripId" element={<ProTripDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('Index ProTrip navigation', () => {
+  const ids = Object.keys(proTripMockData);
+
+  ids.forEach((id, index) => {
+    it(`navigates to detail page for pro trip ${id}`, () => {
+      renderWithRouter();
+
+      fireEvent.click(screen.getByRole('button', { name: /trips pro/i }));
+
+      const viewButtons = screen.getAllByRole('button', { name: /view trip/i });
+      fireEvent.click(viewButtons[index]);
+
+      expect(
+        screen.getByRole('heading', { name: proTripMockData[id].title })
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- test index navigation to Pro Trip detail pages

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cd31ee978832a9badb12de4e699c0