### PR TITLE
Fix Pro Dashboard link

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -269,7 +269,7 @@ const Index = () => {
           <div className="flex items-center gap-4">
             {/* Pro Dashboard Button */}
             <button
-              onClick={() => navigate('/tour/1')}
+              onClick={() => navigate('/tour/pro-1')}
               className="bg-gray-900/80 backdrop-blur-md border border-gray-700 hover:border-yellow-500/50 text-white px-6 py-3 rounded-2xl flex items-center gap-3 transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-xl font-medium"
             >
               <Crown size={20} className="text-yellow-500" />


### PR DESCRIPTION
## Summary
- ensure Pro Dashboard button navigates to `/tour/pro-1`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d90a153a8832aa41bd96404ff4d00