### PR TITLE
Add TourDashboard routing test

### DIFF
--- a/src/pages/__tests__/TourDashboard.test.tsx
+++ b/src/pages/__tests__/TourDashboard.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TourDashboard } from '../../components/TourDashboard';
+import { proTripMockData } from '../../data/proTripMockData';
+
+const renderWithRouter = (path: string) => {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/tour/pro-:proTripId/dashboard" element={<TourDashboard />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('TourDashboard route', () => {
+  it('displays pro trip data for valid id', () => {
+    renderWithRouter('/tour/pro-1/dashboard');
+    expect(screen.getByRole('heading', { name: proTripMockData['1'].title })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test to verify `/tour/pro-:proTripId/dashboard` renders the proper tour dashboard

## Testing
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685df1e34d50832abf614c77fc9d8cc3