### PR TITLE
Adjust ProTrip participant id type

### DIFF
--- a/src/components/MobileProTripCard.tsx
+++ b/src/components/MobileProTripCard.tsx
@@ -5,7 +5,7 @@ import { Calendar, MapPin, Users, Crown } from 'lucide-react';
 import { useIsMobile } from '../hooks/use-mobile';
 
 interface Participant {
-  id: number;
+  id: string;
   name: string;
   avatar: string;
   role: string;

--- a/src/components/ProTripCard.tsx
+++ b/src/components/ProTripCard.tsx
@@ -7,7 +7,7 @@ import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
 interface ProParticipant {
-  id: number;
+  id: string;
   name: string;
   avatar: string;
   role: string;


### PR DESCRIPTION
## Summary
- update `ProParticipant` and mobile `Participant` interfaces to use `string` ids

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df1e2198c832ab4c52fd71eab6a06