### PR TITLE
Fix Google Maps display after fragment tagging bug

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -281,27 +281,21 @@ const Index = () => {
         {/* Main Content - Trip Cards */}
         <div className="mb-8">
           <div className={`grid gap-6 ${isMobile ? 'grid-cols-1' : 'md:grid-cols-2 xl:grid-cols-3'}`}>
-            {viewMode === 'myTrips' ? (
-              trips.map((trip) => (
-                <React.Fragment key={trip.id}>
-                  {isMobile ? (
-                    <MobileTripCard trip={trip} />
+            {viewMode === 'myTrips'
+              ? trips.map((trip) =>
+                  isMobile ? (
+                    <MobileTripCard key={trip.id} trip={trip} />
                   ) : (
-                    <TripCard trip={trip} />
-                  )}
-                </React.Fragment>
-              ))
-            ) : (
-              Object.values(proTripMockData).map((trip) => (
-                <React.Fragment key={trip.id}>
-                  {isMobile ? (
-                    <MobileProTripCard trip={trip} />
+                    <TripCard key={trip.id} trip={trip} />
+                  )
+                )
+              : Object.values(proTripMockData).map((trip) =>
+                  isMobile ? (
+                    <MobileProTripCard key={trip.id} trip={trip} />
                   ) : (
-                    <ProTripCard trip={trip} />
-                  )}
-                </React.Fragment>
-              ))
-            )}
+                    <ProTripCard key={trip.id} trip={trip} />
+                  )
+                )}
           </div>
 
           {/* Empty State for new users */}


### PR DESCRIPTION
## Summary
- avoid applying `data-lov-id` to React fragments by removing them

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685f324a05e0832ab13b5a276ddfa100