### PR TITLE
Fix Pro trip view route and restore full feature set

### DIFF
--- a/src/components/pro/ProTripDetailHeader.tsx
+++ b/src/components/pro/ProTripDetailHeader.tsx
@@ -1,20 +1,33 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Settings, Crown } from 'lucide-react';
+import { ArrowLeft, Settings, Crown, MessageCircle, UserPlus } from 'lucide-react';
 import { UniversalTripAI } from '../UniversalTripAI';
+import { useAuth } from '../../hooks/useAuth';
 
 interface ProTripDetailHeaderProps {
   tripContext: any;
-  onSettingsOpen: () => void;
+  showInbox: boolean;
+  onToggleInbox: () => void;
+  onShowInvite: () => void;
+  onShowTripSettings: () => void;
+  onShowAuth: () => void;
 }
 
-export const ProTripDetailHeader = ({ tripContext, onSettingsOpen }: ProTripDetailHeaderProps) => {
+export const ProTripDetailHeader = ({
+  tripContext,
+  showInbox,
+  onToggleInbox,
+  onShowInvite,
+  onShowTripSettings,
+  onShowAuth
+}: ProTripDetailHeaderProps) => {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   return (
     <div className="flex items-center justify-between mb-8">
-      <button 
+      <button
         onClick={() => navigate('/')}
         className="flex items-center gap-3 text-gray-300 hover:text-white transition-colors group"
       >
@@ -24,19 +37,49 @@ export const ProTripDetailHeader = ({ tripContext, onSettingsOpen }: ProTripDeta
         <span className="font-medium">Back to Trips</span>
       </button>
 
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
         {/* Universal Trip AI Button */}
         <UniversalTripAI tripContext={tripContext} />
 
-        <div className="bg-gradient-to-r from-glass-orange to-glass-yellow p-2 rounded-lg">
-          <Crown size={20} className="text-white" />
+        {/* Pro Badge */}
+        <div className="bg-gradient-to-r from-glass-orange to-glass-yellow backdrop-blur-sm border border-yellow-500/30 rounded-xl px-4 py-2 flex items-center gap-2">
+          <Crown size={16} className="text-white" />
+          <span className="text-white font-medium">PRO</span>
         </div>
-        <button
-          onClick={onSettingsOpen}
-          className="bg-gray-800 p-2 rounded-lg hover:bg-gray-700 transition-colors border border-gray-700 hover:border-yellow-500/50"
-        >
-          <Settings size={20} className="text-white" />
-        </button>
+
+        {user ? (
+          <>
+            <button
+              onClick={onShowInvite}
+              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-xl transition-colors flex items-center gap-2"
+            >
+              <UserPlus size={16} />
+              <span className="hidden sm:inline">Invite</span>
+            </button>
+
+            <button
+              onClick={onToggleInbox}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-xl transition-colors flex items-center gap-2"
+            >
+              <MessageCircle size={16} />
+              <span className="hidden sm:inline">{showInbox ? 'Hide Inbox' : 'Messages'}</span>
+            </button>
+
+            <button
+              onClick={onShowTripSettings}
+              className="bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-xl transition-colors"
+            >
+              <Settings size={20} />
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={onShowAuth}
+            className="bg-gradient-to-r from-glass-orange to-glass-yellow text-white px-6 py-2 rounded-xl transition-colors font-medium"
+          >
+            Sign In
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/pages/ProTripDetail.tsx
+++ b/src/pages/ProTripDetail.tsx
@@ -109,9 +109,13 @@ const ProTripDetail = () => {
     <div className="min-h-screen bg-black">
       <div className="container mx-auto px-6 py-8 max-w-7xl">
         {/* Pro Trip Header */}
-        <ProTripDetailHeader 
+        <ProTripDetailHeader
           tripContext={tripContext}
-          onSettingsOpen={() => setShowTripSettings(true)}
+          showInbox={showInbox}
+          onToggleInbox={() => setShowInbox(!showInbox)}
+          onShowInvite={() => setShowInvite(true)}
+          onShowTripSettings={() => setShowTripSettings(true)}
+          onShowAuth={() => setShowAuth(true)}
         />
 
         {/* Message Inbox - same as regular trips */}


### PR DESCRIPTION
## Summary
- reorder Pro trip routes ahead of general tour route
- expose chat, invites, messages, and settings in `ProTripDetailHeader`
- pass new header props from `ProTripDetail`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68604299ffbc832aacb15a135f5e4bc3