### PR TITLE
Fix tour navigation in MessageInbox

### DIFF
--- a/src/components/MessageInbox.tsx
+++ b/src/components/MessageInbox.tsx
@@ -19,7 +19,7 @@ export const MessageInbox = () => {
     if (message.tripId) {
       navigate(`/trip/${message.tripId}`);
     } else if (message.tourId) {
-      navigate(`/tour/${message.tourId}`);
+      navigate(`/tour/pro-${message.tourId}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- correct the `handleMessageClick` logic so that tour messages route to `/tour/pro-<id>`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618b33a870832a95134549d99605fb