### PR TITLE
Use trip variant accents

### DIFF
--- a/src/components/ProTripCard.tsx
+++ b/src/components/ProTripCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { ProTripData } from '../types/pro';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface ProTripCardProps {
   trip: ProTripData;
@@ -13,6 +14,7 @@ interface ProTripCardProps {
 
 export const ProTripCard = ({ trip }: ProTripCardProps) => {
   const navigate = useNavigate();
+  const { accentColors } = useTripVariant();
 
   const handleViewTrip = () => {
     console.log('Navigating to trip ID:', trip.id);
@@ -40,12 +42,12 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
   };
 
   return (
-    <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-md border border-white/20 rounded-3xl p-6 hover:bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl group hover:border-glass-orange/50 relative overflow-hidden">
+    <div className={`bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-md border border-white/20 rounded-3xl p-6 hover:bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl group hover:border-${accentColors.primary}/50 relative overflow-hidden`}>
       {/* Pro Badge */}
       <div className="absolute top-4 right-4">
         <Tooltip>
           <TooltipTrigger>
-            <div className="bg-gradient-to-r from-glass-orange to-glass-yellow p-2 rounded-lg">
+            <div className={`bg-gradient-to-r ${accentColors.gradient} p-2 rounded-lg`}>
               <Crown size={16} className="text-white" />
             </div>
           </TooltipTrigger>
@@ -57,7 +59,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Header */}
       <div className="mb-4 pr-12">
-        <h3 className="text-xl font-semibold text-white group-hover:text-glass-yellow transition-colors mb-2">
+        <h3 className={`text-xl font-semibold text-white group-hover:text-${accentColors.secondary} transition-colors mb-2`}>
           {trip.title}
         </h3>
         <div className="flex flex-wrap gap-2">
@@ -76,16 +78,16 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Location */}
       <div className="flex items-center gap-3 text-white/80 mb-4">
-        <div className="w-8 h-8 bg-glass-orange/20 backdrop-blur-sm rounded-lg flex items-center justify-center">
-          <MapPin size={16} className="text-glass-orange" />
+        <div className={`w-8 h-8 bg-${accentColors.primary}/20 backdrop-blur-sm rounded-lg flex items-center justify-center`}>
+          <MapPin size={16} className={`text-${accentColors.primary}`} />
         </div>
         <span className="font-medium">{trip.location}</span>
       </div>
 
       {/* Date */}
       <div className="flex items-center gap-3 text-white/80 mb-6">
-        <div className="w-8 h-8 bg-glass-yellow/20 backdrop-blur-sm rounded-lg flex items-center justify-center">
-          <Calendar size={16} className="text-glass-yellow" />
+        <div className={`w-8 h-8 bg-${accentColors.secondary}/20 backdrop-blur-sm rounded-lg flex items-center justify-center`}>
+          <Calendar size={16} className={`text-${accentColors.secondary}`} />
         </div>
         <span className="font-medium">{trip.dateRange}</span>
       </div>
@@ -103,7 +105,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
                 <img
                   src={participant.avatar}
                   alt={participant.name}
-                  className="w-10 h-10 rounded-full border-2 border-white/30 hover:scale-110 transition-transform duration-200 hover:border-glass-orange"
+                  className={`w-10 h-10 rounded-full border-2 border-white/30 hover:scale-110 transition-transform duration-200 hover:border-${accentColors.primary}`}
                   style={{ zIndex: trip.participants.length - index }}
                 />
               </TooltipTrigger>
@@ -121,9 +123,9 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Action Buttons */}
       <div className="flex gap-2">
-        <Button 
+        <Button
           onClick={handleViewTrip}
-          className="flex-1 bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-glass-yellow transition-all duration-300 font-medium hover:shadow-lg"
+          className={`flex-1 bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-${accentColors.secondary} transition-all duration-300 font-medium hover:shadow-lg`}
           variant="ghost"
         >
           <Eye size={16} className="mr-2" />
@@ -149,7 +151,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Pro Features Highlight */}
       <div className="mt-4 pt-4 border-t border-white/10">
-        <div className="text-xs text-glass-yellow/80 flex items-center gap-1">
+        <div className={`text-xs text-${accentColors.secondary}/80 flex items-center gap-1`}>
           <Crown size={12} />
           <span>Pro: Team roles, broadcasts, permissions</span>
         </div>

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -6,6 +6,7 @@ import { ProUpgradeModal } from './ProUpgradeModal';
 import { EnterpriseSettings } from './EnterpriseSettings';
 import { ConsumerSettings } from './ConsumerSettings';
 import { ProfileSection } from './settings/ProfileSection';
+import { useTripVariant } from '../contexts/TripVariantContext';
 import { NotificationsSection } from './settings/NotificationsSection';
 import { SubscriptionSection } from './settings/SubscriptionSection';
 
@@ -19,6 +20,7 @@ export const SettingsMenu = ({ isOpen, onClose }: SettingsMenuProps) => {
   const [showProModal, setShowProModal] = useState(false);
   const [activeSection, setActiveSection] = useState('profile');
   const [settingsType, setSettingsType] = useState<'consumer' | 'enterprise'>('consumer');
+  const { accentColors } = useTripVariant();
 
   if (!isOpen || !user) return null;
 
@@ -95,7 +97,7 @@ export const SettingsMenu = ({ isOpen, onClose }: SettingsMenuProps) => {
                 onClick={() => setSettingsType('consumer')}
                 className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
                   settingsType === 'consumer'
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'text-gray-400 hover:text-white'
                 }`}
               >
@@ -105,7 +107,7 @@ export const SettingsMenu = ({ isOpen, onClose }: SettingsMenuProps) => {
                 onClick={() => setSettingsType('enterprise')}
                 className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
                   settingsType === 'enterprise'
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'text-gray-400 hover:text-white'
                 }`}
               >

--- a/src/components/TourChat.tsx
+++ b/src/components/TourChat.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Send, Radio, Users, MessageCircle } from 'lucide-react';
+import { useTripVariant } from '../contexts/TripVariantContext';
 import { useMessages } from '../hooks/useMessages';
 import { useParams } from 'react-router-dom';
 import { proTripMockData } from '../data/proTripMockData';
@@ -11,6 +12,7 @@ export const TourChat = () => {
   const { getMessagesForTour, addMessage } = useMessages();
   const [message, setMessage] = useState('');
   const [isTyping, setIsTyping] = useState(false);
+  const { accentColors } = useTripVariant();
 
   // Get tour data for context
   const tourData = proTripMockData[finalTourId];
@@ -38,8 +40,8 @@ export const TourChat = () => {
   return (
     <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6">
       <div className="flex items-center gap-3 mb-6">
-        <div className="w-10 h-10 bg-gradient-to-r from-glass-orange/30 to-glass-yellow/30 backdrop-blur-sm rounded-xl flex items-center justify-center">
-          <Radio size={20} className="text-glass-orange" />
+        <div className={`w-10 h-10 bg-gradient-to-r from-${accentColors.primary}/30 to-${accentColors.secondary}/30 backdrop-blur-sm rounded-xl flex items-center justify-center`}>
+          <Radio size={20} className={`text-${accentColors.primary}`} />
         </div>
         <div>
           <h3 className="text-lg font-semibold text-white">Event Chat</h3>
@@ -92,12 +94,12 @@ export const TourChat = () => {
             onKeyPress={handleKeyPress}
             placeholder=""
             rows={2}
-            className="w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl px-4 py-3 pr-12 text-white placeholder-gray-400 focus:outline-none focus:border-glass-orange resize-none"
+            className={`w-full bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl px-4 py-3 pr-12 text-white placeholder-gray-400 focus:outline-none focus:border-${accentColors.primary} resize-none`}
           />
           <button
             onClick={handleSendMessage}
             disabled={!message.trim()}
-            className="absolute right-2 bottom-2 bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 disabled:opacity-50 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-all duration-200"
+            className={`absolute right-2 bottom-2 bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 disabled:opacity-50 disabled:cursor-not-allowed text-white p-2 rounded-lg transition-all duration-200`}
           >
             <Send size={16} />
           </button>

--- a/src/components/TransportationAccommodations.tsx
+++ b/src/components/TransportationAccommodations.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Hotel, Plane, Train, Car, MapPin, Calendar, Eye, EyeOff, Plus, Clock } from 'lucide-react';
 import { TourTrip, TeamMember } from '../types/pro';
 import { useAuth } from '../hooks/useAuth';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface TransportationAccommodationsProps {
   trip: TourTrip;
@@ -12,6 +13,7 @@ interface TransportationAccommodationsProps {
 export const TransportationAccommodations = ({ trip, currentUser }: TransportationAccommodationsProps) => {
   const [showAccommodationDetails, setShowAccommodationDetails] = useState(false);
   const [showTransportationDetails, setShowTransportationDetails] = useState(false);
+  const { accentColors } = useTripVariant();
 
   const canViewAccommodation = () => {
     if (!trip.accommodation?.isPrivate) return true;
@@ -29,8 +31,8 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
     switch (type) {
       case 'flight': return <Plane size={16} className="text-glass-blue" />;
       case 'train': return <Train size={16} className="text-glass-green" />;
-      case 'car': return <Car size={16} className="text-glass-yellow" />;
-      default: return <Car size={16} className="text-glass-orange" />;
+      case 'car': return <Car size={16} className={`text-${accentColors.secondary}`} />;
+      default: return <Car size={16} className={`text-${accentColors.primary}`} />;
     }
   };
 
@@ -38,8 +40,8 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
     <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-3xl p-6 md:p-8">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-xl md:text-2xl font-semibold text-white">Transportation & Accommodations</h2>
-        <div className="bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 backdrop-blur-sm border border-white/20 rounded-xl px-3 py-1">
-          <span className="text-glass-orange font-medium text-sm">PRO</span>
+        <div className={`bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 backdrop-blur-sm border border-white/20 rounded-xl px-3 py-1`}>
+          <span className={`text-${accentColors.primary} font-medium text-sm`}>PRO</span>
         </div>
       </div>
 
@@ -48,8 +50,8 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
         <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 bg-gradient-to-r from-glass-yellow/30 to-glass-orange/30 backdrop-blur-sm rounded-xl flex items-center justify-center">
-                <Hotel size={20} className="text-glass-yellow" />
+              <div className={`w-10 h-10 bg-gradient-to-r from-${accentColors.secondary}/30 to-${accentColors.primary}/30 backdrop-blur-sm rounded-xl flex items-center justify-center`}>
+                <Hotel size={20} className={`text-${accentColors.secondary}`} />
               </div>
               <h3 className="text-lg font-semibold text-white">Accommodation</h3>
             </div>
@@ -67,7 +69,7 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
                 <h4 className="text-white font-medium mb-2">{trip.accommodation.name}</h4>
                 <div className="space-y-2 text-sm text-gray-300">
                   <div className="flex items-start gap-2">
-                    <MapPin size={12} className="mt-1 text-glass-orange flex-shrink-0" />
+                    <MapPin size={12} className={`mt-1 text-${accentColors.primary} flex-shrink-0`} />
                     <span>{trip.accommodation.address}</span>
                   </div>
                   <div className="flex items-center gap-2">
@@ -80,7 +82,7 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
               {!showAccommodationDetails ? (
                 <button
                   onClick={() => setShowAccommodationDetails(true)}
-                  className="text-glass-yellow hover:text-glass-orange text-sm font-medium transition-colors flex items-center gap-2"
+                  className={`text-${accentColors.secondary} hover:text-${accentColors.primary} text-sm font-medium transition-colors flex items-center gap-2`}
                 >
                   <Eye size={12} />
                   Show Confirmation Details
@@ -190,7 +192,7 @@ export const TransportationAccommodations = ({ trip, currentUser }: Transportati
 
       {/* Add Transportation/Accommodation Buttons */}
       <div className="mt-6 flex flex-col sm:flex-row gap-3">
-        <button className="flex-1 bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-glass-yellow transition-all duration-300 font-medium py-3 px-4 rounded-xl flex items-center justify-center gap-2">
+        <button className={`flex-1 bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-${accentColors.secondary} transition-all duration-300 font-medium py-3 px-4 rounded-xl flex items-center justify-center gap-2`}>
           <Plus size={16} />
           Add Accommodation
         </button>

--- a/src/components/TripHeader.tsx
+++ b/src/components/TripHeader.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Calendar, MapPin, Users, Plus, Settings } from 'lucide-react';
 import { InviteModal } from './InviteModal';
 import { useAuth } from '../hooks/useAuth';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface TripHeaderProps {
   trip: {
@@ -23,6 +24,7 @@ interface TripHeaderProps {
 export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
   const { user } = useAuth();
   const [showInvite, setShowInvite] = useState(false);
+  const { accentColors } = useTripVariant();
 
   return (
     <>
@@ -33,11 +35,11 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
             <h1 className="text-4xl font-bold text-white mb-4">{trip.title}</h1>
             <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-6">
               <div className="flex items-center gap-2 text-gray-300">
-                <MapPin size={18} className="text-glass-orange" />
+                <MapPin size={18} className={`text-${accentColors.primary}`} />
                 <span>{trip.location}</span>
               </div>
               <div className="flex items-center gap-2 text-gray-300">
-                <Calendar size={18} className="text-glass-orange" />
+                <Calendar size={18} className={`text-${accentColors.primary}`} />
                 <span>{trip.dateRange}</span>
               </div>
             </div>
@@ -50,7 +52,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
           <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 min-w-[280px]">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <Users size={20} className="text-glass-orange" />
+                <Users size={20} className={`text-${accentColors.primary}`} />
                 <h3 className="text-white font-semibold">Trip Collaborators</h3>
               </div>
               <div className="flex items-center gap-2">
@@ -58,7 +60,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
                 {onManageUsers && (
                   <button
                     onClick={onManageUsers}
-                    className="text-gray-400 hover:text-glass-orange transition-colors p-1 rounded-lg hover:bg-white/10"
+                    className={`text-gray-400 hover:text-${accentColors.primary} transition-colors p-1 rounded-lg hover:bg-white/10`}
                     title="Manage users"
                   >
                     <Settings size={16} />
@@ -83,7 +85,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
             {user && (
               <button
                 onClick={() => setShowInvite(true)}
-                className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-white font-medium py-3 rounded-xl transition-all duration-200 hover:scale-105"
+                className={`w-full flex items-center justify-center gap-2 bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-white font-medium py-3 rounded-xl transition-all duration-200 hover:scale-105`}
               >
                 <Plus size={16} />
                 Invite to Trip

--- a/src/components/TripPreferences.tsx
+++ b/src/components/TripPreferences.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Settings, Sparkles, Crown } from 'lucide-react';
 import { TripPreferences as TripPreferencesType, DIETARY_OPTIONS, VIBE_OPTIONS } from '../types/consumer';
 import { useConsumerSubscription } from '../hooks/useConsumerSubscription';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface TripPreferencesProps {
   tripId: string;
@@ -11,6 +12,7 @@ interface TripPreferencesProps {
 
 export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferencesProps) => {
   const { isPlus } = useConsumerSubscription();
+  const { accentColors } = useTripVariant();
   const [preferences, setPreferences] = useState<TripPreferencesType>({
     dietary: [],
     vibe: [],
@@ -55,10 +57,10 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
       <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 relative">
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm rounded-2xl flex items-center justify-center z-10">
           <div className="text-center">
-            <Crown size={48} className="text-glass-orange mx-auto mb-4" />
+            <Crown size={48} className={`text-${accentColors.primary} mx-auto mb-4`} />
             <h3 className="text-xl font-bold text-white mb-2">Trips Plus Exclusive</h3>
             <p className="text-gray-300 mb-4">Set group preferences to get personalized AI recommendations</p>
-            <button className="bg-gradient-to-r from-glass-orange to-glass-yellow text-white px-6 py-3 rounded-xl font-medium hover:scale-105 transition-transform">
+            <button className={`bg-gradient-to-r ${accentColors.gradient} text-white px-6 py-3 rounded-xl font-medium hover:scale-105 transition-transform`}>
               Upgrade to Trips Plus
             </button>
           </div>
@@ -66,7 +68,7 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
         
         <div className="opacity-30">
           <div className="flex items-center gap-3 mb-6">
-            <Settings size={24} className="text-glass-orange" />
+            <Settings size={24} className={`text-${accentColors.primary}`} />
             <h3 className="text-lg font-semibold text-white">Trip Preferences</h3>
           </div>
           <div className="space-y-6">
@@ -89,16 +91,16 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
   return (
     <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6">
       <div className="flex items-center gap-3 mb-6">
-        <div className="bg-gradient-to-r from-glass-orange/30 to-glass-yellow/30 p-2 rounded-xl">
-          <Sparkles size={20} className="text-glass-orange" />
+        <div className={`bg-gradient-to-r from-${accentColors.primary}/30 to-${accentColors.secondary}/30 p-2 rounded-xl`}>
+          <Sparkles size={20} className={`text-${accentColors.primary}`} />
         </div>
         <div>
           <h3 className="text-lg font-semibold text-white">Trip Preferences</h3>
           <p className="text-gray-400 text-sm">Help our AI make better recommendations</p>
         </div>
         <div className="ml-auto">
-          <div className="bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 px-3 py-1 rounded-full">
-            <span className="text-glass-orange text-sm font-medium">PLUS</span>
+          <div className={`bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 px-3 py-1 rounded-full`}>
+            <span className={`text-${accentColors.primary} text-sm font-medium`}>PLUS</span>
           </div>
         </div>
       </div>
@@ -114,7 +116,7 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
                 onClick={() => handleDietaryChange(option)}
                 className={`px-3 py-2 rounded-full text-sm transition-colors ${
                   preferences.dietary.includes(option)
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
                 }`}
               >
@@ -134,7 +136,7 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
                 onClick={() => handleVibeChange(option)}
                 className={`px-3 py-2 rounded-full text-sm transition-colors ${
                   preferences.vibe.includes(option)
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
                 }`}
               >
@@ -154,7 +156,7 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
                 onClick={() => handleBudgetChange(option as any)}
                 className={`px-4 py-2 rounded-xl text-sm transition-colors capitalize ${
                   preferences.budget === option
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
                 }`}
               >
@@ -174,7 +176,7 @@ export const TripPreferences = ({ tripId, onPreferencesChange }: TripPreferences
                 onClick={() => handleTimeChange(option as any)}
                 className={`px-4 py-2 rounded-xl text-sm transition-colors capitalize ${
                   preferences.timePreference === option
-                    ? 'bg-glass-orange text-white'
+                    ? `bg-${accentColors.primary} text-white`
                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
                 }`}
               >

--- a/src/components/UniversalReviewSummaries.tsx
+++ b/src/components/UniversalReviewSummaries.tsx
@@ -1,17 +1,19 @@
 
 import React from 'react';
 import { Globe } from 'lucide-react';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 export const UniversalReviewSummaries = () => {
+  const { accentColors } = useTripVariant();
   return (
     <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-3xl p-8 shadow-xl hover:bg-white/15 transition-all duration-300">
       {/* Header */}
       <div className="flex items-center gap-3 mb-4">
-        <div className="w-10 h-10 bg-gradient-to-r from-glass-orange/30 to-glass-yellow/30 backdrop-blur-sm rounded-xl flex items-center justify-center">
-          <Globe size={24} className="text-glass-orange" />
+        <div className={`w-10 h-10 bg-gradient-to-r from-${accentColors.primary}/30 to-${accentColors.secondary}/30 backdrop-blur-sm rounded-xl flex items-center justify-center`}>
+          <Globe size={24} className={`text-${accentColors.primary}`} />
         </div>
         <h2 className="text-xl font-semibold text-white">Universal Review Summaries</h2>
-        <span className="bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 backdrop-blur-sm border border-white/20 text-white text-xs font-medium px-3 py-1 rounded-full">
+        <span className={`bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 backdrop-blur-sm border border-white/20 text-white text-xs font-medium px-3 py-1 rounded-full`}>
           Plus Required
         </span>
       </div>
@@ -35,7 +37,7 @@ export const UniversalReviewSummaries = () => {
 
       {/* Upgrade Button */}
       <div className="flex justify-center">
-        <button className="bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-white font-medium px-8 py-3 rounded-2xl transition-all duration-200 hover:scale-105 shadow-lg">
+        <button className={`bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-white font-medium px-8 py-3 rounded-2xl transition-all duration-200 hover:scale-105 shadow-lg`}>
           Upgrade to Plus
         </button>
       </div>

--- a/src/components/chat/GeminiPlusUpgrade.tsx
+++ b/src/components/chat/GeminiPlusUpgrade.tsx
@@ -2,9 +2,11 @@
 import React from 'react';
 import { Crown, Sparkles, Send, MessageCircle } from 'lucide-react';
 import { useConsumerSubscription } from '../../hooks/useConsumerSubscription';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 export const GeminiPlusUpgrade = () => {
   const { upgradeToPlus } = useConsumerSubscription();
+  const { accentColors } = useTripVariant();
 
   return (
     <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl overflow-hidden relative">
@@ -52,7 +54,7 @@ export const GeminiPlusUpgrade = () => {
       {/* Glassmorphism Overlay */}
       <div className="absolute inset-0 bg-black/70 backdrop-blur-md flex items-center justify-center">
         <div className="text-center max-w-md p-8">
-          <div className="w-16 h-16 bg-gradient-to-r from-glass-orange to-glass-yellow rounded-full flex items-center justify-center mx-auto mb-6">
+          <div className={`w-16 h-16 bg-gradient-to-r ${accentColors.gradient} rounded-full flex items-center justify-center mx-auto mb-6`}>
             <Crown size={32} className="text-white" />
           </div>
           
@@ -81,7 +83,7 @@ export const GeminiPlusUpgrade = () => {
           <div className="space-y-3">
             <button
               onClick={upgradeToPlus}
-              className="w-full bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-white font-bold py-4 rounded-xl transition-all duration-200 hover:scale-105 shadow-lg text-lg"
+              className={`w-full bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-white font-bold py-4 rounded-xl transition-all duration-200 hover:scale-105 shadow-lg text-lg`}
             >
               🔓 Unlock with Trips Plus
             </button>

--- a/src/components/pro/ProTripDetailHeader.tsx
+++ b/src/components/pro/ProTripDetailHeader.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Settings, Crown, MessageCircle, UserPlus } from 'lucide-react';
 import { UniversalTripAI } from '../UniversalTripAI';
 import { useAuth } from '../../hooks/useAuth';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface ProTripDetailHeaderProps {
   tripContext: any;
@@ -24,6 +25,7 @@ export const ProTripDetailHeader = ({
 }: ProTripDetailHeaderProps) => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { accentColors } = useTripVariant();
 
   return (
     <div className="flex items-center justify-between mb-8">
@@ -42,7 +44,7 @@ export const ProTripDetailHeader = ({
         <UniversalTripAI tripContext={tripContext} />
 
         {/* Pro Badge */}
-        <div className="bg-gradient-to-r from-glass-orange to-glass-yellow backdrop-blur-sm border border-yellow-500/30 rounded-xl px-4 py-2 flex items-center gap-2">
+        <div className={`bg-gradient-to-r ${accentColors.gradient} backdrop-blur-sm border border-yellow-500/30 rounded-xl px-4 py-2 flex items-center gap-2`}>
           <Crown size={16} className="text-white" />
           <span className="text-white font-medium">PRO</span>
         </div>
@@ -75,7 +77,7 @@ export const ProTripDetailHeader = ({
         ) : (
           <button
             onClick={onShowAuth}
-            className="bg-gradient-to-r from-glass-orange to-glass-yellow text-white px-6 py-2 rounded-xl transition-colors font-medium"
+            className={`bg-gradient-to-r ${accentColors.gradient} text-white px-6 py-2 rounded-xl transition-colors font-medium`}
           >
             Sign In
           </button>

--- a/src/components/pro/ProTripNotFound.tsx
+++ b/src/components/pro/ProTripNotFound.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface ProTripNotFoundProps {
   message: string;
@@ -10,6 +11,7 @@ interface ProTripNotFoundProps {
 
 export const ProTripNotFound = ({ message, details, availableIds }: ProTripNotFoundProps) => {
   const navigate = useNavigate();
+  const { accentColors } = useTripVariant();
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center">
@@ -22,7 +24,7 @@ export const ProTripNotFound = ({ message, details, availableIds }: ProTripNotFo
         )}
         <button
           onClick={() => navigate('/')}
-          className="bg-gradient-to-r from-glass-orange to-glass-yellow text-white px-6 py-3 rounded-xl"
+          className={`bg-gradient-to-r ${accentColors.gradient} text-white px-6 py-3 rounded-xl`}
         >
           Back to Home
         </button>

--- a/src/components/pro/ProTripQuickActions.tsx
+++ b/src/components/pro/ProTripQuickActions.tsx
@@ -1,18 +1,20 @@
 
 import React from 'react';
 import { MessageSquare, FileText, Users } from 'lucide-react';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 export const ProTripQuickActions = () => {
+  const { accentColors } = useTripVariant();
   return (
     <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4">
-      <button className="bg-gray-800/50 hover:bg-gray-700/50 border border-gray-700 hover:border-glass-orange/50 rounded-2xl p-6 transition-all duration-300 text-left group">
-        <MessageSquare className="text-glass-orange mb-3 group-hover:scale-110 transition-transform" size={24} />
+      <button className={`bg-gray-800/50 hover:bg-gray-700/50 border border-gray-700 hover:border-${accentColors.primary}/50 rounded-2xl p-6 transition-all duration-300 text-left group`}>
+        <MessageSquare className={`text-${accentColors.primary} mb-3 group-hover:scale-110 transition-transform`} size={24} />
         <div className="text-white font-medium mb-1">Team Chat</div>
         <div className="text-gray-400 text-sm">Communicate with your team</div>
       </button>
       
-      <button className="bg-gray-800/50 hover:bg-gray-700/50 border border-gray-700 hover:border-glass-yellow/50 rounded-2xl p-6 transition-all duration-300 text-left group">
-        <FileText className="text-glass-yellow mb-3 group-hover:scale-110 transition-transform" size={24} />
+      <button className={`bg-gray-800/50 hover:bg-gray-700/50 border border-gray-700 hover:border-${accentColors.secondary}/50 rounded-2xl p-6 transition-all duration-300 text-left group`}>
+        <FileText className={`text-${accentColors.secondary} mb-3 group-hover:scale-110 transition-transform`} size={24} />
         <div className="text-white font-medium mb-1">Documents</div>
         <div className="text-gray-400 text-sm">Contracts, schedules, and files</div>
       </button>

--- a/src/components/settings/NotificationsSection.tsx
+++ b/src/components/settings/NotificationsSection.tsx
@@ -2,9 +2,11 @@
 import React from 'react';
 import { Bell } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 export const NotificationsSection = () => {
   const { user, updateProfile } = useAuth();
+  const { accentColors } = useTripVariant();
 
   if (!user) return null;
 
@@ -31,7 +33,7 @@ export const NotificationsSection = () => {
             <button
               onClick={() => handleNotificationToggle(key)}
               className={`relative w-12 h-6 rounded-full transition-colors ${
-                value ? 'bg-glass-orange' : 'bg-gray-600'
+                value ? `bg-${accentColors.primary}` : 'bg-gray-600'
               }`}
             >
               <div className={`absolute w-5 h-5 bg-white rounded-full top-0.5 transition-transform ${

--- a/src/components/settings/ProfileSection.tsx
+++ b/src/components/settings/ProfileSection.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { User, Mail, Phone, Building } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface ProfileSectionProps {
   userOrganization?: {
@@ -11,13 +12,14 @@ interface ProfileSectionProps {
 
 export const ProfileSection = ({ userOrganization }: ProfileSectionProps) => {
   const { user, updateProfile } = useAuth();
+  const { accentColors } = useTripVariant();
 
   if (!user) return null;
 
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <div className="w-20 h-20 bg-gradient-to-r from-glass-orange to-glass-yellow rounded-full mx-auto mb-4 flex items-center justify-center">
+        <div className={`w-20 h-20 bg-gradient-to-r ${accentColors.gradient} rounded-full mx-auto mb-4 flex items-center justify-center`}>
           {user.avatar ? (
             <img src={user.avatar} alt="Profile" className="w-full h-full rounded-full" />
           ) : (
@@ -28,9 +30,9 @@ export const ProfileSection = ({ userOrganization }: ProfileSectionProps) => {
         <p className="text-gray-400 text-sm">{user.email || user.phone}</p>
         {userOrganization && (
           <div className="mt-2">
-            <div className="inline-flex items-center gap-2 bg-glass-orange/20 px-3 py-1 rounded-full">
-              <Building size={14} className="text-glass-orange" />
-              <span className="text-glass-orange text-sm font-medium">{userOrganization.name}</span>
+            <div className={`inline-flex items-center gap-2 bg-${accentColors.primary}/20 px-3 py-1 rounded-full`}>
+              <Building size={14} className={`text-${accentColors.primary}`} />
+              <span className={`text-${accentColors.primary} text-sm font-medium`}>{userOrganization.name}</span>
             </div>
           </div>
         )}
@@ -43,7 +45,7 @@ export const ProfileSection = ({ userOrganization }: ProfileSectionProps) => {
             type="text"
             value={user.displayName}
             onChange={(e) => updateProfile({ displayName: e.target.value })}
-            className="w-full bg-white/10 border border-white/20 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-glass-orange"
+            className={`w-full bg-white/10 border border-white/20 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-${accentColors.primary}`}
           />
         </div>
 

--- a/src/components/settings/SubscriptionSection.tsx
+++ b/src/components/settings/SubscriptionSection.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Crown, Building } from 'lucide-react';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface SubscriptionSectionProps {
   userOrganization?: {
@@ -13,35 +14,36 @@ interface SubscriptionSectionProps {
   onShowEnterpriseSettings: () => void;
 }
 
-export const SubscriptionSection = ({ 
-  userOrganization, 
-  onShowProModal, 
-  onShowEnterpriseSettings 
+export const SubscriptionSection = ({
+  userOrganization,
+  onShowProModal,
+  onShowEnterpriseSettings
 }: SubscriptionSectionProps) => {
+  const { accentColors } = useTripVariant();
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold text-white">Subscription</h3>
         {userOrganization?.hasProAccess && (
-          <div className="flex items-center gap-2 bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 px-3 py-1 rounded-full">
-            <Crown size={14} className="text-glass-orange" />
-            <span className="text-glass-orange text-sm font-medium">ENTERPRISE</span>
+          <div className={`flex items-center gap-2 bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 px-3 py-1 rounded-full`}>
+            <Crown size={14} className={`text-${accentColors.primary}`} />
+            <span className={`text-${accentColors.primary} text-sm font-medium`}>ENTERPRISE</span>
           </div>
         )}
       </div>
 
       {userOrganization?.hasProAccess ? (
-        <div className="bg-gradient-to-r from-glass-orange/10 to-glass-yellow/10 border border-glass-orange/20 rounded-xl p-6">
+        <div className={`bg-gradient-to-r from-${accentColors.primary}/10 to-${accentColors.secondary}/10 border border-${accentColors.primary}/20 rounded-xl p-6`}>
           <h4 className="text-white font-semibold mb-2">Enterprise Access Active</h4>
           <p className="text-gray-300 text-sm mb-4">
             You have access to all Enterprise features through {userOrganization.name}
           </p>
           <div className="text-sm text-gray-400 mb-4">
-            Role: <span className="text-glass-orange capitalize">{userOrganization.role}</span>
+            Role: <span className={`text-${accentColors.primary} capitalize`}>{userOrganization.role}</span>
           </div>
           <button
             onClick={onShowEnterpriseSettings}
-            className="bg-glass-orange hover:bg-glass-orange/80 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+            className={`bg-${accentColors.primary} hover:bg-${accentColors.primary}/80 text-white px-4 py-2 rounded-lg font-medium transition-colors`}
           >
             Manage Organization
           </button>
@@ -52,7 +54,7 @@ export const SubscriptionSection = ({
           <p className="text-gray-300 text-sm mb-4">Perfect for personal trips and small groups</p>
           <button
             onClick={onShowProModal}
-            className="w-full bg-gradient-to-r from-glass-orange to-glass-yellow text-white font-medium py-3 rounded-xl hover:scale-105 transition-transform"
+            className={`w-full bg-gradient-to-r ${accentColors.gradient} text-white font-medium py-3 rounded-xl hover:scale-105 transition-transform`}
           >
             Upgrade to Enterprise
           </button>

--- a/src/components/tour/TourScheduleSection.tsx
+++ b/src/components/tour/TourScheduleSection.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Plus, MapPin, Mic, Music, Trophy, Briefcase, Hotel, Plane } from 'lucide-react';
 import { Tour, TourTrip } from '../../types/pro';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface TourScheduleSectionProps {
   tour: Tour;
@@ -10,11 +11,12 @@ interface TourScheduleSectionProps {
 
 export const TourScheduleSection = ({ tour }: TourScheduleSectionProps) => {
   const navigate = useNavigate();
+  const { accentColors } = useTripVariant();
 
   const getCategoryIcon = (category: TourTrip['category']) => {
     switch (category) {
-      case 'headline': return <Mic size={16} className="text-glass-orange" />;
-      case 'private': return <Briefcase size={16} className="text-glass-yellow" />;
+      case 'headline': return <Mic size={16} className={`text-${accentColors.primary}`} />;
+      case 'private': return <Briefcase size={16} className={`text-${accentColors.secondary}`} />;
       case 'college': return <Trophy size={16} className="text-glass-green" />;
       case 'festival': return <Music size={16} className="text-purple-400" />;
       case 'corporate': return <Briefcase size={16} className="text-blue-400" />;
@@ -34,7 +36,7 @@ export const TourScheduleSection = ({ tour }: TourScheduleSectionProps) => {
     <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-3xl p-6 md:p-8 mb-8">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
         <h2 className="text-xl md:text-2xl font-semibold text-white">Schedule</h2>
-        <button className="bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-white font-medium px-4 md:px-6 py-3 rounded-2xl transition-all duration-200 hover:scale-105 shadow-lg flex items-center gap-2">
+        <button className={`bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-white font-medium px-4 md:px-6 py-3 rounded-2xl transition-all duration-200 hover:scale-105 shadow-lg flex items-center gap-2`}>
           <Plus size={20} />
           Add Event
         </button>
@@ -49,11 +51,11 @@ export const TourScheduleSection = ({ tour }: TourScheduleSectionProps) => {
           >
             <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-gradient-to-r from-glass-orange/30 to-glass-yellow/30 backdrop-blur-sm rounded-xl flex items-center justify-center flex-shrink-0">
+                <div className={`w-12 h-12 bg-gradient-to-r from-${accentColors.primary}/30 to-${accentColors.secondary}/30 backdrop-blur-sm rounded-xl flex items-center justify-center flex-shrink-0`}>
                   {getCategoryIcon(trip.category)}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="text-lg font-semibold text-white group-hover:text-glass-yellow transition-colors mb-1">
+                  <h3 className={`text-lg font-semibold text-white group-hover:text-${accentColors.secondary} transition-colors mb-1`}>
                     {trip.city}
                   </h3>
                   <div className="space-y-1">
@@ -75,7 +77,7 @@ export const TourScheduleSection = ({ tour }: TourScheduleSectionProps) => {
                     {trip.status}
                   </div>
                 </div>
-                <div className="w-2 h-2 bg-glass-orange rounded-full opacity-0 group-hover:opacity-100 transition-opacity"></div>
+                <div className={`w-2 h-2 bg-${accentColors.primary} rounded-full opacity-0 group-hover:opacity-100 transition-opacity`}></div>
               </div>
             </div>
             
@@ -83,7 +85,7 @@ export const TourScheduleSection = ({ tour }: TourScheduleSectionProps) => {
             <div className="mt-4 pt-4 border-t border-white/10">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
                 <div className="flex items-center gap-2 text-gray-400">
-                  <Hotel size={12} className="text-glass-yellow" />
+                  <Hotel size={12} className={`text-${accentColors.secondary}`} />
                   <span className="truncate">{trip.accommodation?.name} - {trip.accommodation?.confirmationNumber}</span>
                 </div>
                 <div className="flex items-center gap-2 text-gray-400">


### PR DESCRIPTION
## Summary
- connect TripHeader to trip accent colors
- refactor TripPreferences to rely on variant accent colors
- tweak TransportationAccommodations styles to use accent colors
- use accent colors in TourScheduleSection, TourChat, and various pro features
- update settings screens to share accent colors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618b68e98c832ab033f1af0aef6341