### PR TITLE
Use accentColors for gold styles

### DIFF
--- a/src/components/MobileProTripCard.tsx
+++ b/src/components/MobileProTripCard.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Calendar, MapPin, Users, Crown } from 'lucide-react';
 import { useIsMobile } from '../hooks/use-mobile';
 import { ProTripData } from '../types/pro';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface MobileProTripCardProps {
   trip: ProTripData;
@@ -12,6 +13,7 @@ interface MobileProTripCardProps {
 export const MobileProTripCard = ({ trip }: MobileProTripCardProps) => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+  const { accentColors } = useTripVariant();
 
   const handleViewTrip = () => {
     navigate(`/tour/pro-${trip.id}`);
@@ -34,13 +36,13 @@ export const MobileProTripCard = ({ trip }: MobileProTripCardProps) => {
   return (
     <div className={`bg-gradient-to-br ${getCategoryColor(trip.category)} backdrop-blur-xl border rounded-2xl overflow-hidden transition-all duration-300 shadow-lg hover:scale-[1.02]`}>
       {/* Pro Badge */}
-      <div className="absolute top-3 right-3 z-10 bg-gradient-to-r from-glass-orange to-glass-yellow px-2 py-1 rounded-full flex items-center gap-1">
+      <div className={`absolute top-3 right-3 z-10 bg-gradient-to-r ${accentColors.gradient} px-2 py-1 rounded-full flex items-center gap-1`}>
         <Crown size={12} className="text-black" />
         <span className="text-xs font-bold text-black">PRO</span>
       </div>
 
       {/* Mobile Header */}
-      <div className="relative h-36 bg-gradient-to-br from-glass-orange/10 to-glass-yellow/10 p-4">
+      <div className={`relative h-36 bg-gradient-to-br from-${accentColors.primary}/10 to-${accentColors.secondary}/10 p-4`}>
         <div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1501594907352-04cda38ebc29?w=400&h=200&fit=crop')] bg-cover bg-center opacity-10"></div>
         <div className="relative z-10 h-full flex flex-col justify-between">
           <div className="flex-1">
@@ -51,11 +53,11 @@ export const MobileProTripCard = ({ trip }: MobileProTripCardProps) => {
               {trip.title}
             </h3>
             <div className="flex items-center gap-2 text-white/80 text-sm mb-1">
-              <MapPin size={14} className="text-glass-orange" />
+              <MapPin size={14} className={`text-${accentColors.primary}`} />
               <span className="font-medium truncate">{trip.location}</span>
             </div>
             <div className="flex items-center gap-2 text-white/80 text-sm">
-              <Calendar size={14} className="text-glass-orange" />
+              <Calendar size={14} className={`text-${accentColors.primary}`} />
               <span className="font-medium">{trip.dateRange}</span>
             </div>
           </div>
@@ -82,7 +84,7 @@ export const MobileProTripCard = ({ trip }: MobileProTripCardProps) => {
         <div className="mb-4">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              <Users size={14} className="text-glass-orange" />
+              <Users size={14} className={`text-${accentColors.primary}`} />
               <span className="text-sm text-gray-300 font-medium">Team</span>
             </div>
             <span className="text-xs text-gray-500">{trip.participants.length} members</span>
@@ -113,9 +115,9 @@ export const MobileProTripCard = ({ trip }: MobileProTripCardProps) => {
         </div>
 
         {/* Action Button */}
-        <button 
+        <button
           onClick={handleViewTrip}
-          className="w-full bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-black font-semibold py-4 rounded-xl transition-all duration-300 shadow-lg"
+          className={`w-full bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-black font-semibold py-4 rounded-xl transition-all duration-300 shadow-lg`}
         >
           Manage Tour
         </button>

--- a/src/components/ProTripCard.tsx
+++ b/src/components/ProTripCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { ProTripData } from '../types/pro';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface ProTripCardProps {
   trip: ProTripData;
@@ -13,6 +14,7 @@ interface ProTripCardProps {
 
 export const ProTripCard = ({ trip }: ProTripCardProps) => {
   const navigate = useNavigate();
+  const { accentColors } = useTripVariant();
 
   const handleViewTrip = () => {
     console.log('Navigating to trip ID:', trip.id);
@@ -40,12 +42,12 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
   };
 
   return (
-    <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-md border border-white/20 rounded-3xl p-6 hover:bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl group hover:border-glass-orange/50 relative overflow-hidden">
+    <div className={`bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-md border border-white/20 rounded-3xl p-6 hover:bg-white/15 transition-all duration-300 hover:scale-105 hover:shadow-xl group hover:border-${accentColors.primary}/50 relative overflow-hidden`}>
       {/* Pro Badge */}
       <div className="absolute top-4 right-4">
         <Tooltip>
           <TooltipTrigger>
-            <div className="bg-gradient-to-r from-glass-orange to-glass-yellow p-2 rounded-lg">
+            <div className={`bg-gradient-to-r ${accentColors.gradient} p-2 rounded-lg`}>
               <Crown size={16} className="text-white" />
             </div>
           </TooltipTrigger>
@@ -57,7 +59,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Header */}
       <div className="mb-4 pr-12">
-        <h3 className="text-xl font-semibold text-white group-hover:text-glass-yellow transition-colors mb-2">
+        <h3 className={`text-xl font-semibold text-white group-hover:text-${accentColors.secondary} transition-colors mb-2`}>
           {trip.title}
         </h3>
         <div className="flex flex-wrap gap-2">
@@ -76,16 +78,16 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Location */}
       <div className="flex items-center gap-3 text-white/80 mb-4">
-        <div className="w-8 h-8 bg-glass-orange/20 backdrop-blur-sm rounded-lg flex items-center justify-center">
-          <MapPin size={16} className="text-glass-orange" />
+        <div className={`w-8 h-8 bg-${accentColors.primary}/20 backdrop-blur-sm rounded-lg flex items-center justify-center`}>
+          <MapPin size={16} className={`text-${accentColors.primary}`} />
         </div>
         <span className="font-medium">{trip.location}</span>
       </div>
 
       {/* Date */}
       <div className="flex items-center gap-3 text-white/80 mb-6">
-        <div className="w-8 h-8 bg-glass-yellow/20 backdrop-blur-sm rounded-lg flex items-center justify-center">
-          <Calendar size={16} className="text-glass-yellow" />
+        <div className={`w-8 h-8 bg-${accentColors.secondary}/20 backdrop-blur-sm rounded-lg flex items-center justify-center`}>
+          <Calendar size={16} className={`text-${accentColors.secondary}`} />
         </div>
         <span className="font-medium">{trip.dateRange}</span>
       </div>
@@ -103,7 +105,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
                 <img
                   src={participant.avatar}
                   alt={participant.name}
-                  className="w-10 h-10 rounded-full border-2 border-white/30 hover:scale-110 transition-transform duration-200 hover:border-glass-orange"
+                  className={`w-10 h-10 rounded-full border-2 border-white/30 hover:scale-110 transition-transform duration-200 hover:border-${accentColors.primary}`}
                   style={{ zIndex: trip.participants.length - index }}
                 />
               </TooltipTrigger>
@@ -121,9 +123,9 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Action Buttons */}
       <div className="flex gap-2">
-        <Button 
+        <Button
           onClick={handleViewTrip}
-          className="flex-1 bg-gradient-to-r from-glass-orange/20 to-glass-yellow/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-glass-yellow transition-all duration-300 font-medium hover:shadow-lg"
+          className={`flex-1 bg-gradient-to-r from-${accentColors.primary}/20 to-${accentColors.secondary}/20 backdrop-blur-sm border border-white/20 hover:border-white/40 text-white hover:text-${accentColors.secondary} transition-all duration-300 font-medium hover:shadow-lg`}
           variant="ghost"
         >
           <Eye size={16} className="mr-2" />
@@ -149,7 +151,7 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
 
       {/* Pro Features Highlight */}
       <div className="mt-4 pt-4 border-t border-white/10">
-        <div className="text-xs text-glass-yellow/80 flex items-center gap-1">
+        <div className={`text-xs text-${accentColors.secondary}/80 flex items-center gap-1`}>
           <Crown size={12} />
           <span>Pro: Team roles, broadcasts, permissions</span>
         </div>

--- a/src/components/TripHeader.tsx
+++ b/src/components/TripHeader.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Calendar, MapPin, Users, Plus, Settings } from 'lucide-react';
 import { InviteModal } from './InviteModal';
 import { useAuth } from '../hooks/useAuth';
+import { useTripVariant } from '../contexts/TripVariantContext';
 
 interface TripHeaderProps {
   trip: {
@@ -23,6 +24,7 @@ interface TripHeaderProps {
 export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
   const { user } = useAuth();
   const [showInvite, setShowInvite] = useState(false);
+  const { accentColors } = useTripVariant();
 
   return (
     <>
@@ -33,11 +35,11 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
             <h1 className="text-4xl font-bold text-white mb-4">{trip.title}</h1>
             <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-6">
               <div className="flex items-center gap-2 text-gray-300">
-                <MapPin size={18} className="text-glass-orange" />
+                <MapPin size={18} className={`text-${accentColors.primary}`} />
                 <span>{trip.location}</span>
               </div>
               <div className="flex items-center gap-2 text-gray-300">
-                <Calendar size={18} className="text-glass-orange" />
+                <Calendar size={18} className={`text-${accentColors.primary}`} />
                 <span>{trip.dateRange}</span>
               </div>
             </div>
@@ -50,7 +52,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
           <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 min-w-[280px]">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <Users size={20} className="text-glass-orange" />
+                <Users size={20} className={`text-${accentColors.primary}`} />
                 <h3 className="text-white font-semibold">Trip Collaborators</h3>
               </div>
               <div className="flex items-center gap-2">
@@ -58,7 +60,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
                 {onManageUsers && (
                   <button
                     onClick={onManageUsers}
-                    className="text-gray-400 hover:text-glass-orange transition-colors p-1 rounded-lg hover:bg-white/10"
+                    className={`text-gray-400 hover:text-${accentColors.primary} transition-colors p-1 rounded-lg hover:bg-white/10`}
                     title="Manage users"
                   >
                     <Settings size={16} />
@@ -83,7 +85,7 @@ export const TripHeader = ({ trip, onManageUsers }: TripHeaderProps) => {
             {user && (
               <button
                 onClick={() => setShowInvite(true)}
-                className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-glass-orange to-glass-yellow hover:from-glass-orange/80 hover:to-glass-yellow/80 text-white font-medium py-3 rounded-xl transition-all duration-200 hover:scale-105"
+                className={`w-full flex items-center justify-center gap-2 bg-gradient-to-r ${accentColors.gradient} hover:from-${accentColors.primary}/80 hover:to-${accentColors.secondary}/80 text-white font-medium py-3 rounded-xl transition-all duration-200 hover:scale-105`}
               >
                 <Plus size={16} />
                 Invite to Trip

--- a/src/components/pro/ProTripNotFound.tsx
+++ b/src/components/pro/ProTripNotFound.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTripVariant } from '../../contexts/TripVariantContext';
 
 interface ProTripNotFoundProps {
   message: string;
@@ -10,6 +11,7 @@ interface ProTripNotFoundProps {
 
 export const ProTripNotFound = ({ message, details, availableIds }: ProTripNotFoundProps) => {
   const navigate = useNavigate();
+  const { accentColors } = useTripVariant();
 
   return (
     <div className="min-h-screen bg-black flex items-center justify-center">
@@ -22,7 +24,7 @@ export const ProTripNotFound = ({ message, details, availableIds }: ProTripNotFo
         )}
         <button
           onClick={() => navigate('/')}
-          className="bg-gradient-to-r from-glass-orange to-glass-yellow text-white px-6 py-3 rounded-xl"
+          className={`bg-gradient-to-r ${accentColors.gradient} text-white px-6 py-3 rounded-xl`}
         >
           Back to Home
         </button>


### PR DESCRIPTION
## Summary
- add `useTripVariant` to various components
- replace hard-coded gold classes with values from `accentColors`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618b06e228832abe14a8ccd779cbaf