### PR TITLE
Use env var for Google Maps API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and set your API key
+VITE_GOOGLE_MAPS_API_KEY=
+

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env` file by copying `.env.example` and fill in your Google Maps API key.
+
+```
+cp .env.example .env
+VITE_GOOGLE_MAPS_API_KEY=<your-key>
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/20feaa04-0946-4c68-a68d-0eb88cc1b9c4) and click on Share -> Publish.

--- a/src/components/GoogleMapsEmbed.tsx
+++ b/src/components/GoogleMapsEmbed.tsx
@@ -10,7 +10,15 @@ export const GoogleMapsEmbed = ({ className }: GoogleMapsEmbedProps) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const apiKey = 'AIzaSyAWm0vayRrQJHpMc6XcShcge52hGTt9BV4';
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
+
+  if (!apiKey) {
+    return (
+      <div className={`relative w-full h-full flex items-center justify-center ${className}`}> 
+        <p className="text-gray-500 text-sm">Google Maps API key is not configured.</p>
+      </div>
+    );
+  }
   
   const getEmbedUrl = () => {
     const query = searchQuery.trim() || 'New York City';

--- a/src/utils/distanceCalculator.ts
+++ b/src/utils/distanceCalculator.ts
@@ -1,7 +1,8 @@
 
 import { BasecampLocation, PlaceWithDistance, DistanceCalculationSettings } from '../types/basecamp';
 
-const GOOGLE_MAPS_API_KEY = 'AIzaSyAWm0vayRrQJHpMc6XcShcge52hGTt9BV4';
+// Google Maps API key is supplied via Vite environment variables
+const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined;
 
 export class DistanceCalculator {
   private static cache = new Map<string, any>();
@@ -71,6 +72,10 @@ export class DistanceCalculator {
     place: PlaceWithDistance,
     mode: 'driving' | 'walking'
   ): Promise<number | null> {
+    if (!GOOGLE_MAPS_API_KEY) {
+      console.warn('Google Maps API key is missing');
+      return null;
+    }
     const origin = `${basecamp.coordinates.lat},${basecamp.coordinates.lng}`;
     const destination = place.coordinates 
       ? `${place.coordinates.lat},${place.coordinates.lng}`
@@ -103,6 +108,10 @@ export class DistanceCalculator {
 
   static async geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
     try {
+      if (!GOOGLE_MAPS_API_KEY) {
+        console.warn('Google Maps API key is missing');
+        return null;
+      }
       const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${GOOGLE_MAPS_API_KEY}`;
       const response = await fetch(url);
       const data = await response.json();


### PR DESCRIPTION
## Summary
- ignore `.env` files
- document `VITE_GOOGLE_MAPS_API_KEY` environment variable
- load Google Maps API key from `import.meta.env`
- show message if API key missing
- guard distance calculations when no API key

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686294e75924832aa39c30006af0f737