### PR TITLE
Implement Supabase auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@supabase/supabase-js": "^2.43.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,7 +1,9 @@
 
 import { useState, useEffect, createContext, useContext } from 'react';
+import { User as SupabaseUser } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabase';
 
-interface User {
+interface AuthUser {
   id: string;
   email?: string;
   phone?: string;
@@ -18,102 +20,110 @@ interface User {
 }
 
 interface AuthContextType {
-  user: User | null;
+  user: AuthUser | null;
   isLoading: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   signInWithPhone: (phone: string, code: string) => Promise<void>;
   signUp: (email: string, password: string, displayName: string) => Promise<void>;
   signOut: () => Promise<void>;
-  updateProfile: (updates: Partial<User>) => Promise<void>;
+  updateProfile: (updates: Partial<AuthUser>) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+const defaultSettings = {
+  messages: true,
+  broadcasts: true,
+  tripUpdates: true,
+  email: true,
+  push: false,
+};
+
+const mapUser = (sbUser: SupabaseUser): AuthUser => ({
+  id: sbUser.id,
+  email: sbUser.email ?? undefined,
+  phone: sbUser.phone ?? undefined,
+  displayName: sbUser.user_metadata?.displayName || sbUser.email || '',
+  avatar: sbUser.user_metadata?.avatar,
+  isPro: sbUser.user_metadata?.isPro ?? false,
+  notificationSettings: sbUser.user_metadata?.notificationSettings || defaultSettings,
+});
+
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<User | null>({
-    id: '1',
-    email: 'demo@example.com',
-    displayName: 'Demo User',
-    isPro: false,
-    notificationSettings: {
-      messages: true,
-      broadcasts: true,
-      tripUpdates: true,
-      email: true,
-      push: false
-    }
-  });
-  const [isLoading, setIsLoading] = useState(false);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      if (data.user) {
+        setUser(mapUser(data.user));
+      }
+      setIsLoading(false);
+    };
+
+    loadUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser(mapUser(session.user));
+      } else {
+        setUser(null);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
 
   const signIn = async (email: string, password: string) => {
     setIsLoading(true);
-    // TODO: Implement Supabase auth
-    setTimeout(() => {
-      setUser({
-        id: '1',
-        email,
-        displayName: 'Demo User',
-        isPro: false,
-        notificationSettings: {
-          messages: true,
-          broadcasts: true,
-          tripUpdates: true,
-          email: true,
-          push: false
-        }
-      });
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
       setIsLoading(false);
-    }, 1000);
+      throw error;
+    }
+    setIsLoading(false);
   };
 
   const signInWithPhone = async (phone: string, code: string) => {
     setIsLoading(true);
-    // TODO: Implement Supabase phone auth
-    setTimeout(() => {
-      setUser({
-        id: '1',
-        phone,
-        displayName: 'Demo User',
-        isPro: false,
-        notificationSettings: {
-          messages: true,
-          broadcasts: true,
-          tripUpdates: true,
-          email: true,
-          push: false
-        }
-      });
+    const { error } = await supabase.auth.signInWithOtp({ phone, token: code });
+    if (error) {
       setIsLoading(false);
-    }, 1000);
+      throw error;
+    }
+    setIsLoading(false);
   };
 
   const signUp = async (email: string, password: string, displayName: string) => {
     setIsLoading(true);
-    // TODO: Implement Supabase signup
-    setTimeout(() => {
-      setUser({
-        id: '1',
-        email,
-        displayName,
-        isPro: false,
-        notificationSettings: {
-          messages: true,
-          broadcasts: true,
-          tripUpdates: true,
-          email: true,
-          push: false
-        }
-      });
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { displayName } },
+    });
+    if (error) {
       setIsLoading(false);
-    }, 1000);
+      throw error;
+    }
+    setIsLoading(false);
   };
 
   const signOut = async () => {
+    setIsLoading(true);
+    await supabase.auth.signOut();
     setUser(null);
+    setIsLoading(false);
   };
 
-  const updateProfile = async (updates: Partial<User>) => {
-    if (user) {
+  const updateProfile = async (updates: Partial<AuthUser>) => {
+    if (!user) return;
+    const { error } = await supabase.auth.updateUser({ data: updates });
+    if (!error) {
       setUser({ ...user, ...updates });
     }
   };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- integrate Supabase client
- connect `useAuth` hook to Supabase sign in/out/signup APIs
- map Supabase user data to app user
- add `@supabase/supabase-js` dependency

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686294f0503c832a9b62fbea92689ad0