### PR TITLE
Fix syntax error in TripGrid

### DIFF
--- a/src/components/home/TripGrid.tsx
+++ b/src/components/home/TripGrid.tsx
@@ -49,7 +49,7 @@ export const TripGrid = ({ viewMode, trips, proTrips, events }: TripGridProps) =
       return isMobile ? (
         <MobileEventCard key={index} event={event} />
       ) : (
-        <EventCard key={index} event={event} />;
+        <EventCard key={index} event={event} />
       )
     } else {
       return null;


### PR DESCRIPTION
## Summary
- remove an extra semicolon in TripGrid renderEventCard

## Testing
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_68634e77f55c832a91a6d345f19c7107