### PR TITLE
Switch to Gemini AI with Scira fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Configuring the Gemini API
+
+The Supabase edge function `gemini-chat` requires a `GEMINI_API_KEY` environment variable. Set this variable in your deployment environment with your Google Gemini API key so the app can retrieve real responses.

--- a/src/components/GeminiAIChat.tsx
+++ b/src/components/GeminiAIChat.tsx
@@ -139,7 +139,7 @@ export const GeminiAIChat = ({ tripId, basecamp, preferences }: GeminiAIChatProp
         <div className="flex-1">
           <h3 className="text-lg font-semibold text-white">AI Travel Assistant</h3>
           <div className="flex items-center gap-2">
-            <p className="text-gray-400 text-sm">Powered by Scira AI</p>
+            <p className="text-gray-400 text-sm">Powered by Google Gemini</p>
             <div className="flex items-center gap-1">
               {getStatusIcon()}
               <span className="text-gray-400 text-xs">{getStatusText()}</span>

--- a/src/components/UniversalTripAI.tsx
+++ b/src/components/UniversalTripAI.tsx
@@ -183,7 +183,7 @@ export const UniversalTripAI = ({ tripContext }: UniversalTripAIProps) => {
             </div>
           </SheetTitle>
           <SheetDescription className="text-gray-400">
-            Powered by Scira AI • Context: {contextLimit}
+            Powered by Google Gemini • Context: {contextLimit}
           </SheetDescription>
         </SheetHeader>
 


### PR DESCRIPTION
## Summary
- call Gemini first in `SciraAIService` and fallback to Scira
- show `Powered by Google Gemini` in chat UIs
- document required `GEMINI_API_KEY`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686409f91b44832ab52c93ffc6efaa62