### PR TITLE
Add OpenAI service integration

### DIFF
--- a/src/services/aiFeatures.ts
+++ b/src/services/aiFeatures.ts
@@ -1,5 +1,5 @@
 
-import { SciraAIService } from './sciraAI';
+import { OpenAIService } from './openAI';
 
 export interface ReviewAnalysisResult {
   text: string;
@@ -24,43 +24,30 @@ export interface AiFeatureResponse<T> {
 export class AiFeatureService {
   static async analyzeReviews(url: string): Promise<AiFeatureResponse<ReviewAnalysisResult>> {
     try {
-      const result = await SciraAIService.analyzeReviews(url);
+      const result = await OpenAIService.analyzeReviews(url);
       return { success: true, data: result };
     } catch (error) {
       console.error('Review Analysis Error:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }
 
   static async generateAudioOverview(url: string, userId?: string, tripId?: string): Promise<AiFeatureResponse<AudioOverviewResult>> {
-    try {
-      // Create a minimal trip context for audio generation
-      const tripContext = {
-        id: tripId || 'unknown',
-        title: 'Trip Overview',
-        location: 'Various locations',
-        dateRange: 'Current period',
-        isPro: false
-      };
+    if (!userId) {
+      return { success: false, error: 'User not authenticated' };
+    }
 
-      const result = await SciraAIService.generateAudioSummary(tripContext);
-      
-      return { 
-        success: true, 
-        data: {
-          summary: result.summary,
-          audioUrl: result.audioUrl,
-          duration: result.duration
-        }
-      };
+    try {
+      const result = await OpenAIService.generateAudioSummary(url, userId, tripId);
+      return { success: true, data: result };
     } catch (error) {
       console.error('Audio Overview Error:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }

--- a/src/services/openAI.ts
+++ b/src/services/openAI.ts
@@ -1,0 +1,61 @@
+export interface OpenAIReviewResult {
+  text: string;
+  sentiment: 'positive' | 'negative' | 'neutral';
+  score: number;
+  platforms: string[];
+}
+
+export interface OpenAIAudioResult {
+  summary: string;
+  audioUrl: string;
+  duration: number;
+  fileKey?: string;
+}
+
+export class OpenAIService {
+  private static readonly REVIEW_ENDPOINT = '/api/ai-features';
+  private static readonly AUDIO_ENDPOINT = '/api/generate-audio-summary';
+
+  static async analyzeReviews(url: string): Promise<OpenAIReviewResult> {
+    const res = await fetch(this.REVIEW_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ feature: 'reviews', url })
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Review analysis failed');
+    }
+
+    const data = await res.json();
+    return data;
+  }
+
+  static async generateAudioSummary(url: string, userId: string, tripId?: string): Promise<OpenAIAudioResult> {
+    const res = await fetch(this.AUDIO_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, user_id: userId, trip_id: tripId })
+    });
+
+    if (!res.ok) {
+      let message: string;
+      try {
+        const err = await res.json();
+        message = err.error || err.message;
+      } catch {
+        message = await res.text();
+      }
+      throw new Error(message || 'Audio summary failed');
+    }
+
+    const data = await res.json();
+    return {
+      summary: data.summary,
+      audioUrl: data.audioUrl,
+      duration: data.duration,
+      fileKey: data.fileKey
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- create `OpenAIService` for review analysis and audio summaries
- use `OpenAIService` in AI feature helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646abae984832a9afbc06de6b62fab