### PR TITLE
Rename Gemini components to OpenAI

### DIFF
--- a/src/components/OpenAIChat.tsx
+++ b/src/components/OpenAIChat.tsx
@@ -3,12 +3,12 @@ import React, { useState } from 'react';
 import { Sparkles, WifiOff, Wifi, AlertCircle } from 'lucide-react';
 import { useConsumerSubscription } from '../hooks/useConsumerSubscription';
 import { TripPreferences } from '../types/consumer';
-import { SciraAIService, TripContext } from '../services/sciraAI';
+import { OpenAIService, TripContext } from '../services/sciraAI';
 import { ChatMessages } from './chat/ChatMessages';
 import { ChatInput } from './chat/ChatInput';
-import { GeminiPlusUpgrade } from './chat/GeminiPlusUpgrade';
+import { AIChatUpgrade } from './chat/AIChatUpgrade';
 
-interface GeminiAIChatProps {
+interface OpenAIChatProps {
   tripId: string;
   basecamp?: { name: string; address: string };
   preferences?: TripPreferences;
@@ -22,7 +22,7 @@ interface ChatMessage {
   isFromFallback?: boolean;
 }
 
-export const GeminiAIChat = ({ tripId, basecamp, preferences }: GeminiAIChatProps) => {
+export const OpenAIChat = ({ tripId, basecamp, preferences }: OpenAIChatProps) => {
   const { isPlus } = useConsumerSubscription();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputMessage, setInputMessage] = useState('');
@@ -54,8 +54,8 @@ export const GeminiAIChat = ({ tripId, basecamp, preferences }: GeminiAIChatProp
         isPro: false
       };
 
-      const context = SciraAIService.buildTripContext(tripContext);
-      const response = await SciraAIService.querySciraAI(inputMessage, context, {
+      const context = OpenAIService.buildTripContext(tripContext);
+      const response = await OpenAIService.queryOpenAI(inputMessage, context, {
         temperature: 0.7,
         maxTokens: 1024,
         webSearch: true
@@ -127,7 +127,7 @@ export const GeminiAIChat = ({ tripId, basecamp, preferences }: GeminiAIChatProp
   };
 
   if (!isPlus) {
-    return <GeminiPlusUpgrade />;
+    return <AIChatUpgrade />;
   }
 
   return (
@@ -139,7 +139,7 @@ export const GeminiAIChat = ({ tripId, basecamp, preferences }: GeminiAIChatProp
         <div className="flex-1">
           <h3 className="text-lg font-semibold text-white">AI Travel Assistant</h3>
           <div className="flex items-center gap-2">
-            <p className="text-gray-400 text-sm">Powered by Google Gemini</p>
+            <p className="text-gray-400 text-sm">Powered by OpenAI</p>
             <div className="flex items-center gap-1">
               {getStatusIcon()}
               <span className="text-gray-400 text-xs">{getStatusText()}</span>

--- a/src/components/UniversalTripAI.tsx
+++ b/src/components/UniversalTripAI.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Send, Sparkles, MessageCircle, ExternalLink, AlertCircle, Wifi, WifiOff } from 'lucide-react';
 import { useConsumerSubscription } from '../hooks/useConsumerSubscription';
 import { TripPreferences } from '../types/consumer';
-import { SciraAIService, TripContext } from '../services/sciraAI';
+import { OpenAIService, TripContext } from '../services/sciraAI';
 import {
   Sheet,
   SheetContent,
@@ -53,8 +53,8 @@ export const UniversalTripAI = ({ tripContext }: UniversalTripAIProps) => {
     setIsTyping(true);
 
     try {
-      const context = SciraAIService.buildTripContext(tripContext);
-      const response = await SciraAIService.querySciraAI(inputMessage, context, {
+      const context = OpenAIService.buildTripContext(tripContext);
+      const response = await OpenAIService.queryOpenAI(inputMessage, context, {
         temperature: 0.3,
         maxTokens: tripContext.isPro ? 2048 : 1024,
         webSearch: true,

--- a/src/components/chat/AIChatUpgrade.tsx
+++ b/src/components/chat/AIChatUpgrade.tsx
@@ -4,7 +4,7 @@ import { Crown, Sparkles, Send, MessageCircle } from 'lucide-react';
 import { useConsumerSubscription } from '../../hooks/useConsumerSubscription';
 import { useTripVariant } from '../../contexts/TripVariantContext';
 
-export const GeminiPlusUpgrade = () => {
+export const AIChatUpgrade = () => {
   const { upgradeToPlus } = useConsumerSubscription();
   const { accentColors } = useTripVariant();
 
@@ -18,7 +18,7 @@ export const GeminiPlusUpgrade = () => {
           </div>
           <div>
             <h3 className="text-lg font-semibold text-white">AI Travel Assistant</h3>
-            <p className="text-gray-400 text-sm">Powered by Google Gemini</p>
+            <p className="text-gray-400 text-sm">Powered by OpenAI</p>
           </div>
         </div>
 
@@ -59,11 +59,11 @@ export const GeminiPlusUpgrade = () => {
           </div>
           
           <h3 className="text-2xl font-bold text-white mb-3">✨ Unlock Smart Trip Planning with Trips Plus</h3>
-          <p className="text-gray-300 mb-6">Your personal AI travel assistant—powered by Google Gemini—is ready to build the perfect trip.</p>
+          <p className="text-gray-300 mb-6">Your personal AI travel assistant is ready to build the perfect trip.</p>
           
           <div className="space-y-2 text-left mb-8">
             <div className="flex items-center gap-2 text-gray-300">
-              <span className="text-green-400">✅</span> AI Chatbot powered by Google Gemini
+              <span className="text-green-400">✅</span> AI Chatbot powered by OpenAI
             </div>
             <div className="flex items-center gap-2 text-gray-300">
               <span className="text-green-400">✅</span> Smart suggestions based on your Basecamp

--- a/src/components/events/EventDetailContent.tsx
+++ b/src/components/events/EventDetailContent.tsx
@@ -4,7 +4,7 @@ import { Crown, Sparkles, Users, Calendar, UserCheck, Network, TrendingUp } from
 import { TripTabs } from '../TripTabs';
 import { PlacesSection } from '../PlacesSection';
 import { TripPreferences } from '../TripPreferences';
-import { GeminiAIChat } from '../GeminiAIChat';
+import { OpenAIChat } from '../OpenAIChat';
 import { TripSearchTab } from '../TripSearchTab';
 import { RegistrationTab } from './RegistrationTab';
 import { AgendaBuilder } from './AgendaBuilder';
@@ -106,8 +106,8 @@ export const EventDetailContent = ({
         );
       case 'ai-chat':
         return (
-          <GeminiAIChat 
-            tripId={tripId} 
+          <OpenAIChat
+            tripId={tripId}
             basecamp={basecamp}
             preferences={tripPreferences}
           />

--- a/src/components/pro/ProTabContent.tsx
+++ b/src/components/pro/ProTabContent.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CalendarIcon, DollarSign, Shield, FileCheck, Tv, Award } from 'lucide-react';
 import { TripTabs } from '../TripTabs';
 import { PlacesSection } from '../PlacesSection';
-import { GeminiAIChat } from '../GeminiAIChat';
+import { OpenAIChat } from '../OpenAIChat';
 import { TripSearchTab } from '../TripSearchTab';
 import { RosterTab } from './RosterTab';
 import { EquipmentTracking } from './EquipmentTracking';
@@ -183,8 +183,8 @@ export const ProTabContent = ({
         );
       case 'ai-chat':
         return (
-          <GeminiAIChat 
-            tripId={tripId} 
+          <OpenAIChat
+            tripId={tripId}
             basecamp={basecamp}
             preferences={tripPreferences}
           />

--- a/src/components/trip/TripDetailContent.tsx
+++ b/src/components/trip/TripDetailContent.tsx
@@ -4,7 +4,7 @@ import { Crown, Sparkles } from 'lucide-react';
 import { TripTabs } from '../TripTabs';
 import { PlacesSection } from '../PlacesSection';
 import { TripPreferences } from '../TripPreferences';
-import { GeminiAIChat } from '../GeminiAIChat';
+import { OpenAIChat } from '../OpenAIChat';
 import { TripSearchTab } from '../TripSearchTab';
 import { TripPreferences as TripPreferencesType } from '../../types/consumer';
 import { useTripVariant } from '../../contexts/TripVariantContext';
@@ -55,8 +55,8 @@ export const TripDetailContent = ({
         );
       case 'ai-chat':
         return (
-          <GeminiAIChat 
-            tripId={tripId} 
+          <OpenAIChat
+            tripId={tripId}
             basecamp={basecamp}
             preferences={tripPreferences}
           />

--- a/src/services/aiFeatures.ts
+++ b/src/services/aiFeatures.ts
@@ -1,5 +1,5 @@
 
-import { SciraAIService } from './sciraAI';
+import { OpenAIService } from './sciraAI';
 
 export interface ReviewAnalysisResult {
   text: string;
@@ -24,7 +24,7 @@ export interface AiFeatureResponse<T> {
 export class AiFeatureService {
   static async analyzeReviews(url: string): Promise<AiFeatureResponse<ReviewAnalysisResult>> {
     try {
-      const result = await SciraAIService.analyzeReviews(url);
+      const result = await OpenAIService.analyzeReviews(url);
       return { success: true, data: result };
     } catch (error) {
       console.error('Review Analysis Error:', error);
@@ -46,7 +46,7 @@ export class AiFeatureService {
         isPro: false
       };
 
-      const result = await SciraAIService.generateAudioSummary(tripContext);
+      const result = await OpenAIService.generateAudioSummary(tripContext);
       
       return { 
         success: true, 

--- a/src/services/sciraAI.ts
+++ b/src/services/sciraAI.ts
@@ -2,14 +2,14 @@
 import { TripPreferences } from '../types/consumer';
 import { ProTripData } from '../types/pro';
 
-export interface SciraAIConfig {
+export interface OpenAIConfig {
   temperature?: number;
   maxTokens?: number;
   webSearch?: boolean;
   citations?: boolean;
 }
 
-export interface SciraAIResponse {
+export interface OpenAIResponse {
   content: string;
   sources?: Array<{
     title: string;
@@ -37,7 +37,7 @@ export interface TripContext {
   proData?: ProTripData;
 }
 
-export class SciraAIService {
+export class OpenAIService {
   private static readonly SCIRA_API_BASE = 'https://scira.sh/api';
   private static readonly GEMINI_ENDPOINT = '/api/gemini-chat';
   private static readonly FALLBACK_ENABLED = true;
@@ -119,7 +119,7 @@ SAVED LINKS:`;
     return context;
   }
 
-  private static async generateFallbackResponse(query: string, context: string): Promise<SciraAIResponse> {
+  private static async generateFallbackResponse(query: string, context: string): Promise<OpenAIResponse> {
     // Intelligent fallback responses based on query patterns
     const lowerQuery = query.toLowerCase();
     
@@ -171,11 +171,11 @@ SAVED LINKS:`;
            error.code === 'NETWORK_ERROR';
   }
 
-  static async querySciraAI(
+  static async queryOpenAI(
     query: string,
     context: string,
-    config: SciraAIConfig = {}
-  ): Promise<SciraAIResponse> {
+    config: OpenAIConfig = {}
+  ): Promise<OpenAIResponse> {
     const prompt = `${context}
 
 USER QUESTION: ${query}
@@ -301,7 +301,7 @@ Provide a comprehensive sentiment analysis including:
 
 Format your response as a detailed analysis.`;
 
-      const response = await this.querySciraAI(prompt, '', {
+      const response = await this.queryOpenAI(prompt, '', {
         webSearch: true,
         temperature: 0.2
       });
@@ -351,7 +351,7 @@ ${context}
 
 Please create a natural, conversational script that would work well as an audio overview of this trip. Include key details, highlights, and practical information that travelers would want to know.`;
 
-      const response = await this.querySciraAI(prompt, '', {
+      const response = await this.queryOpenAI(prompt, '', {
         temperature: 0.4,
         maxTokens: 1000
       });


### PR DESCRIPTION
## Summary
- rename `GeminiAIChat` to `OpenAIChat`
- rename `GeminiPlusUpgrade` to `AIChatUpgrade` and adjust wording
- update all imports to use new names
- switch `SciraAIService` to `OpenAIService`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646aa45db4832abca9ed67f9e05d49