### PR TITLE
Switch Gemini chat to OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
-## Configuring the Gemini API
+## Configuring the OpenAI API
 
-The Supabase edge function `gemini-chat` requires a `GEMINI_API_KEY` environment variable. Set this variable in your deployment environment with your Google Gemini API key so the app can retrieve real responses.
+The Supabase edge function `openai-chat` requires an `OPENAI_API_KEY` environment variable. Set this variable in your deployment environment with your OpenAI API key so the app can retrieve real responses.

--- a/src/components/chat/geminiService.ts
+++ b/src/components/chat/geminiService.ts
@@ -29,7 +29,7 @@ export class GeminiService {
 
   async callAPI(message: string, config: GeminiAPIConfig, tripContext?: any): Promise<string> {
     // Call the Supabase Edge Function instead of direct Gemini API
-    const response = await fetch('/api/gemini-chat', {
+    const response = await fetch('/api/openai-chat', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/services/sciraAI.ts
+++ b/src/services/sciraAI.ts
@@ -39,7 +39,7 @@ export interface TripContext {
 
 export class SciraAIService {
   private static readonly SCIRA_API_BASE = 'https://scira.sh/api';
-  private static readonly GEMINI_ENDPOINT = '/api/gemini-chat';
+  private static readonly OPENAI_ENDPOINT = '/api/openai-chat';
   private static readonly FALLBACK_ENABLED = true;
   
   static buildTripContext(tripContext: TripContext): string {
@@ -183,9 +183,9 @@ USER QUESTION: ${query}
 Please provide a helpful, specific response based on the trip context above. If you need current information about places, events, or travel conditions, use web search capabilities.`;
 
     try {
-      console.log('Attempting Gemini AI request...');
+      console.log('Attempting OpenAI chat request...');
 
-      const geminiRes = await fetch(this.GEMINI_ENDPOINT, {
+      const openaiRes = await fetch(this.OPENAI_ENDPOINT, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -202,16 +202,16 @@ Please provide a helpful, specific response based on the trip context above. If 
         })
       });
 
-      if (geminiRes.ok) {
-        const geminiData = await geminiRes.json();
-        console.log('Gemini AI response received:', geminiData);
+      if (openaiRes.ok) {
+        const geminiData = await openaiRes.json();
+        console.log('OpenAI response received:', geminiData);
         return { content: geminiData.response, sources: [], citations: [], isFromFallback: false };
       } else {
-        const text = await geminiRes.text();
-        throw new Error(`Gemini HTTP ${geminiRes.status}: ${text}`);
+        const text = await openaiRes.text();
+        throw new Error(`OpenAI HTTP ${openaiRes.status}: ${text}`);
       }
     } catch (gemError) {
-      console.error('Gemini AI Request Failed:', gemError);
+      console.error('OpenAI Request Failed:', gemError);
     }
 
     try {

--- a/supabase/functions/openai-chat/index.ts
+++ b/supabase/functions/openai-chat/index.ts
@@ -1,4 +1,3 @@
-
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
 const corsHeaders = {
@@ -12,47 +11,33 @@ serve(async (req) => {
   }
 
   try {
-    const { message, tripContext, config } = await req.json()
+    const { message, config } = await req.json()
 
-    // Get the Gemini API key from environment variables
-    const apiKey = Deno.env.get('GEMINI_API_KEY')
+    const apiKey = Deno.env.get('OPENAI_API_KEY')
     if (!apiKey) {
-      throw new Error('Gemini API key not configured')
+      throw new Error('OpenAI API key not configured')
     }
 
-    // Call Gemini API
-    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' + apiKey, {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
+        'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        contents: [{
-          parts: [{
-            text: message
-          }]
-        }],
-        generationConfig: config || {
-          temperature: 0.3,
-          topK: 40,
-          topP: 0.95,
-          maxOutputTokens: 1024,
-        }
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: message }],
+        ...config,
       }),
     })
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}))
-      throw new Error(`Gemini API Error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`)
+      throw new Error(`OpenAI API Error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`)
     }
 
     const data = await response.json()
-    
-    if (!data.candidates || !data.candidates[0] || !data.candidates[0].content) {
-      throw new Error('Invalid response format from Gemini API')
-    }
-    
-    const aiResponse = data.candidates[0].content.parts[0].text
+    const aiResponse = data.choices?.[0]?.message?.content || ''
 
     return new Response(
       JSON.stringify({ response: aiResponse }),


### PR DESCRIPTION
## Summary
- drop the old `gemini-chat` edge function
- add a new `openai-chat` edge function
- call `/api/openai-chat` from front-end services
- update docs for the OpenAI API key

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646ab82914832a9ca2a41eaa781e57