### PR TITLE
Add AI message composer and scheduling system

### DIFF
--- a/src/components/AiMessageComposer.tsx
+++ b/src/components/AiMessageComposer.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { OpenAIService } from '../services/OpenAIService';
+import { useMessages } from '../hooks/useMessages';
+import { Send } from 'lucide-react';
+
+export const AiMessageComposer = () => {
+  const { addMessage } = useMessages();
+  const [prompt, setPrompt] = useState('');
+  const [tone, setTone] = useState<'friendly' | 'professional' | 'funny'>('friendly');
+  const [isSending, setIsSending] = useState(false);
+
+  const send = async () => {
+    if (!prompt.trim()) return;
+    setIsSending(true);
+    try {
+      const response = await OpenAIService.queryOpenAI(prompt, { tone });
+      await addMessage(response);
+      setPrompt('');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2 bg-slate-800/30 p-4 rounded-xl">
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        rows={3}
+        className="w-full bg-slate-900 border border-slate-700 rounded-lg p-2 text-white"
+        placeholder="Ask the AI to craft a message..."
+      />
+      <div className="flex items-center justify-between gap-2">
+        <select
+          value={tone}
+          onChange={(e) => setTone(e.target.value as any)}
+          className="bg-slate-900 text-white border border-slate-700 rounded px-2 py-1"
+        >
+          <option value="friendly">Friendly</option>
+          <option value="professional">Professional</option>
+          <option value="funny">Funny</option>
+        </select>
+        <button
+          onClick={send}
+          disabled={isSending || !prompt.trim()}
+          className="flex items-center gap-1 bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
+        >
+          <Send size={16} /> Send
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TemplateLibrary.tsx
+++ b/src/components/TemplateLibrary.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const templates = [
+  { id: 'reminder', text: 'Reminder: ' },
+  { id: 'update', text: 'Quick update: ' },
+  { id: 'announcement', text: 'Announcement: ' }
+];
+
+export const TemplateLibrary = ({ onSelect }: { onSelect: (text: string) => void }) => (
+  <div className="space-y-2">
+    {templates.map(t => (
+      <button
+        key={t.id}
+        onClick={() => onSelect(t.text)}
+        className="block bg-slate-700 text-white px-3 py-1 rounded w-full text-left"
+      >
+        {t.text}
+      </button>
+    ))}
+  </div>
+);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useMessages } from '../hooks/useMessages';
+
+export const AdminDashboard = () => {
+  const { scheduledMessages } = useMessages();
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">Scheduled Messages</h1>
+      <ul className="space-y-2">
+        {scheduledMessages.map(m => (
+          <li key={m.id} className="border border-slate-700 rounded p-3">
+            <p>{m.content}</p>
+            <p className="text-xs text-slate-400">{new Date(m.sendAt).toLocaleString()}</p>
+            <p className="text-xs">Priority: {m.priority}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/services/OpenAIService.ts
+++ b/src/services/OpenAIService.ts
@@ -1,0 +1,56 @@
+export interface OpenAIOptions {
+  tone?: 'friendly' | 'professional' | 'funny';
+  maxTokens?: number;
+}
+
+export class OpenAIService {
+  private static apiUrl = 'https://api.openai.com/v1/chat/completions';
+
+  static async queryOpenAI(prompt: string, options: OpenAIOptions = {}): Promise<string> {
+    const apiKey = (import.meta as any).env.VITE_OPENAI_API_KEY as string | undefined;
+    if (!apiKey) {
+      console.warn('OpenAI API key not configured');
+      return 'OpenAI API key missing';
+    }
+
+    const messages = [] as Array<{ role: 'system' | 'user'; content: string }>;
+    if (options.tone) {
+      messages.push({ role: 'system', content: `Respond in a ${options.tone} tone.` });
+    }
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages,
+        max_tokens: options.maxTokens ?? 256,
+        temperature: 0.7
+      })
+    });
+
+    if (!res.ok) {
+      throw new Error(`OpenAI error ${res.status}`);
+    }
+    const data = await res.json();
+    return data.choices?.[0]?.message?.content?.trim() || '';
+  }
+
+  static async classifyPriority(text: string): Promise<'urgent' | 'reminder' | 'fyi'> {
+    const prompt = `Classify the priority of this message into one of: urgent, reminder, fyi.\nMessage: "${text}"\nPriority:`;
+    try {
+      const resp = await this.queryOpenAI(prompt, { maxTokens: 10 });
+      const l = resp.toLowerCase();
+      if (l.includes('urgent')) return 'urgent';
+      if (l.includes('reminder')) return 'reminder';
+      return 'fyi';
+    } catch (e) {
+      console.error('Priority classification failed', e);
+      return 'fyi';
+    }
+  }
+}

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -11,6 +11,7 @@ export interface Message {
   tourName?: string;
   timestamp: string;
   isRead: boolean;
+  priority?: 'urgent' | 'reminder' | 'fyi';
   mentions?: string[];
   threadId?: string;
   replyToId?: string;
@@ -29,4 +30,9 @@ export interface UnifiedInboxData {
   messages: Message[];
   threads: MessageThread[];
   totalUnread: number;
+}
+
+export interface ScheduledMessage extends Message {
+  sendAt: string;
+  isSent: boolean;
 }

--- a/supabase/functions/daily-digest/index.ts
+++ b/supabase/functions/daily-digest/index.ts
@@ -1,0 +1,79 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+interface RequestBody {
+  user_id: string;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { user_id }: RequestBody = await req.json();
+    if (!user_id) {
+      return new Response(JSON.stringify({ error: 'Missing user_id' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: messages, error } = await supabase
+      .from('messages')
+      .select('content')
+      .eq('user_id', user_id)
+      .gt('created_at', since);
+
+    if (error) throw error;
+
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+    if (!openaiKey) throw new Error('OPENAI_API_KEY not set');
+
+    const summary = await summarize(messages.map(m => m.content).join('\n'), openaiKey);
+
+    return new Response(JSON.stringify({ summary }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});
+
+async function summarize(text: string, key: string): Promise<string> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'Summarize the following messages into a brief daily digest.' },
+        { role: 'user', content: text },
+      ],
+      max_tokens: 150,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OpenAI error: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() || '';
+}


### PR DESCRIPTION
## Summary
- create `OpenAIService` with query and classification helpers
- build `AiMessageComposer` using selected tone
- extend `useMessages` with scheduled messages and automatic dispatch
- support priority tagging on message creation
- expose templates and admin dashboard
- add Supabase `daily-digest` function for morning summaries

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646abc65b4832aa9f82d2e04a9b781