### PR TITLE
Integrate AI composer into TripChat

### DIFF
--- a/src/components/TripChat.tsx
+++ b/src/components/TripChat.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Send, Search, MessageCircle, User, Settings } from 'lucide-react';
 import { useMessages } from '../hooks/useMessages';
 import { useParams } from 'react-router-dom';
+import { AiMessageComposer } from '../components/AiMessageComposer';
 
 interface TripChatProps {
   groupChatEnabled?: boolean;
@@ -132,6 +133,11 @@ export const TripChat = ({ groupChatEnabled = true }: TripChatProps) => {
             </p>
           </div>
         )}
+      </div>
+
+      {/* AI Composer */}
+      <div className="mb-6">
+        <AiMessageComposer />
       </div>
 
       {/* Message Input */}


### PR DESCRIPTION
## Summary
- add AiMessageComposer import
- render AiMessageComposer above the manual message input

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68656b551ce0832a932a4b1b5c303f4b