### PR TITLE
Add message scheduling function

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -95,21 +95,23 @@ export const useMessages = () => {
 
   const scheduleMessage = async (content: string, sendAt: Date, tripId?: string, tourId?: string) => {
     const priority = await OpenAIService.classifyPriority(content);
-    const newMsg: ScheduledMessage = {
-      id: Date.now().toString(),
-      content,
-      senderId: 'current-user',
-      senderName: 'You',
-      senderAvatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face',
-      timestamp: sendAt.toISOString(),
-      isRead: true,
-      tripId,
-      tourId,
-      priority,
-      sendAt: sendAt.toISOString(),
-      isSent: false
-    };
-    setScheduledMessages(prev => [...prev, newMsg]);
+    try {
+      await fetch('/api/message-scheduler', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          content,
+          send_at: sendAt.toISOString(),
+          trip_id: tripId,
+          user_id: 'current-user',
+          priority
+        })
+      });
+    } catch (err) {
+      console.error('Failed to schedule message', err);
+    }
   };
 
   const searchMessages = (query: string) => {

--- a/supabase/functions/message-scheduler/index.ts
+++ b/supabase/functions/message-scheduler/index.ts
@@ -1,0 +1,73 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+  try {
+    if (req.method === 'POST') {
+      const body = await req.json();
+      const { content, send_at, trip_id, user_id, priority } = body;
+      if (!content || !send_at || !user_id) {
+        return new Response(
+          JSON.stringify({ error: 'Missing required fields' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const { error } = await supabase.from('scheduled_messages').insert({
+        id: crypto.randomUUID(),
+        content,
+        send_at,
+        trip_id,
+        user_id,
+        priority,
+      });
+
+      if (error) throw error;
+
+      return new Response(JSON.stringify({ success: true }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Poll for due messages
+    const now = new Date().toISOString();
+    const { data: due, error } = await supabase
+      .from('scheduled_messages')
+      .select('*')
+      .lte('send_at', now);
+
+    if (error) throw error;
+
+    for (const msg of due ?? []) {
+      await supabase.from('messages').insert({
+        content: msg.content,
+        trip_id: msg.trip_id,
+        user_id: msg.user_id,
+        priority: msg.priority,
+      });
+      await supabase.from('scheduled_messages').delete().eq('id', msg.id);
+    }
+
+    return new Response(JSON.stringify({ processed: due?.length || 0 }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/002_scheduled_messages.sql
+++ b/supabase/migrations/002_scheduled_messages.sql
@@ -1,0 +1,9 @@
+-- Create scheduled_messages table
+CREATE TABLE IF NOT EXISTS scheduled_messages (
+  id UUID PRIMARY KEY,
+  content TEXT NOT NULL,
+  send_at TIMESTAMPTZ NOT NULL,
+  trip_id UUID,
+  user_id UUID NOT NULL,
+  priority TEXT
+);


### PR DESCRIPTION
## Summary
- create scheduled_messages table migration
- add new edge function `message-scheduler`
- post new schedules from `useMessages`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656b551d64832aab2a8d7a5f93b90d