### PR TITLE
Add migrations for message priority and daily digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,11 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 ## Configuring the OpenAI API
 
 Set the `OPENAI_API_KEY` environment variable with your OpenAI API key. The new `openai-chat` Supabase function requires this variable to generate responses.
+
+## Database Migrations
+
+Apply the migrations in numeric order to keep the schema consistent:
+
+1. `001_audio_summaries.sql`
+2. `002_add_priority_to_messages.sql`
+3. `003_create_daily_digests.sql`

--- a/supabase/migrations/002_add_priority_to_messages.sql
+++ b/supabase/migrations/002_add_priority_to_messages.sql
@@ -1,0 +1,5 @@
+-- Migration 002: Add priority column to messages
+-- Run after 001_audio_summaries.sql
+
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 0;

--- a/supabase/migrations/003_create_daily_digests.sql
+++ b/supabase/migrations/003_create_daily_digests.sql
@@ -1,0 +1,10 @@
+-- Migration 003: Create daily_digests table
+-- Run after 002_add_priority_to_messages.sql
+
+CREATE TABLE IF NOT EXISTS daily_digests (
+  id TEXT PRIMARY KEY,
+  user_id UUID NOT NULL,
+  digest_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  summary TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add migration 002 to introduce `priority` column on `messages`
- add migration 003 to create `daily_digests` table
- document migration order in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656b59ff10832ab00b6b9414e9b50b