### PR TITLE
Add AI service and composer tests

### DIFF
--- a/src/pages/__tests__/AiMessageComposer.test.tsx
+++ b/src/pages/__tests__/AiMessageComposer.test.tsx
@@ -1,0 +1,31 @@
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('../../hooks/useMessages');
+vi.mock('../../services/OpenAIService', () => ({
+  OpenAIService: { queryOpenAI: vi.fn() }
+}));
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AiMessageComposer } from '../../components/AiMessageComposer';
+import { useMessages } from '../../hooks/useMessages';
+import { OpenAIService } from '../../services/OpenAIService';
+
+
+describe('AiMessageComposer', () => {
+  it('calls addMessage and clears the prompt after send', async () => {
+    const addMessage = vi.fn();
+    vi.mocked(useMessages).mockReturnValue({ addMessage });
+    vi.mocked(OpenAIService.queryOpenAI).mockResolvedValue('response');
+
+    render(<AiMessageComposer />);
+    const textarea = screen.getByPlaceholderText('Ask the AI to craft a message...') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(addMessage).toHaveBeenCalledWith('response');
+    });
+
+    expect(textarea.value).toBe('');
+  });
+});

--- a/src/pages/__tests__/OpenAIServicePriority.test.ts
+++ b/src/pages/__tests__/OpenAIServicePriority.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenAIService } from '../../services/OpenAIService';
+
+const originalEnv = { ...(import.meta as any).env };
+
+describe('OpenAIService.classifyPriority', () => {
+  beforeEach(() => {
+    (import.meta as any).env = { ...originalEnv, VITE_OPENAI_API_KEY: 'test' };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (import.meta as any).env = originalEnv;
+  });
+
+  it.each([
+    ['urgent', 'This is urgent!'],
+    ['reminder', 'Just a reminder for tomorrow'],
+    ['fyi', 'FYI about something']
+  ])('returns %s when model responds with %s', async (expected, response) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: response } }] })
+    } as any));
+
+    const result = await OpenAIService.classifyPriority('text');
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `OpenAIService.classifyPriority`
- add tests for `AiMessageComposer` behavior

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656b5a232c832abb2acf94613f2926