### PR TITLE
Rename Education category to School

### DIFF
--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -27,7 +27,7 @@ const getRoleIcon = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('manager')) return Users;
       return Building;
     
-    case 'Education & Academic':
+    case 'School':
       if (lowerRole.includes('teacher') || lowerRole.includes('supervisor')) return GraduationCap;
       if (lowerRole.includes('student')) return Users;
       return Shield;
@@ -67,7 +67,7 @@ const getRoleColor = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('executive')) return 'bg-red-500';
       return 'bg-blue-500';
     
-    case 'Education & Academic':
+    case 'School':
       if (lowerRole.includes('teacher')) return 'bg-blue-500';
       if (lowerRole.includes('student')) return 'bg-green-500';
       return 'bg-gray-500';

--- a/src/data/pro-trips/harrisElementaryFieldTrip.ts
+++ b/src/data/pro-trips/harrisElementaryFieldTrip.ts
@@ -7,7 +7,7 @@ export const harrisElementaryFieldTrip: ProTripData = {
   location: 'Washington DC',
   dateRange: 'Apr 10 - Apr 14, 2025',
   category: 'Education',
-  proTripCategory: 'Education & Academic',
+  proTripCategory: 'School',
   tags: ['Education', 'Field Trip', 'Middle School'],
   participants: [
     { id: 16, name: 'Ms. Jennifer Wilson', avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=40&h=40&fit=crop&crop=face', role: 'Teacher' },

--- a/src/data/pro-trips/indianaUniversityDebate.ts
+++ b/src/data/pro-trips/indianaUniversityDebate.ts
@@ -7,7 +7,7 @@ export const indianaUniversityDebate: ProTripData = {
   location: 'Austin TX',
   dateRange: 'Mar 1 - Mar 6, 2025',
   category: 'Academic',
-  proTripCategory: 'Education & Academic',
+  proTripCategory: 'School',
   tags: ['Academic', 'Debate', 'Championships'],
   participants: [
     { id: 20, name: 'Prof. Michael Davis', avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face', role: 'Teacher' },

--- a/src/types/pro.ts
+++ b/src/types/pro.ts
@@ -290,7 +290,7 @@ export interface ProTripData {
   location: string;
   dateRange: string;
   category: string;
-  proTripCategory?: 'Sports & Athletics' | 'Music & Entertainment Tours' | 'Corporate & Business' | 'Education & Academic' | 'TV/Film Production' | 'Startup & Tech';
+  proTripCategory?: 'Sports & Athletics' | 'Music & Entertainment Tours' | 'Corporate & Business' | 'School' | 'TV/Film Production' | 'Startup & Tech';
   tags: string[];
   participants: ProTripParticipant[];
   budget: {

--- a/src/types/proCategories.ts
+++ b/src/types/proCategories.ts
@@ -1,11 +1,11 @@
 
 import { LucideIcon } from 'lucide-react';
 
-export type ProTripCategory = 
+export type ProTripCategory =
   | 'Sports & Athletics'
-  | 'Music & Entertainment Tours' 
+  | 'Music & Entertainment Tours'
   | 'Corporate & Business'
-  | 'Education & Academic'
+  | 'School'
   | 'TV/Film Production'
   | 'Startup & Tech';
 
@@ -63,9 +63,9 @@ export const PRO_CATEGORY_CONFIGS: Record<ProTripCategory, ProCategoryConfig> = 
       leaderLabel: 'Event Lead'
     }
   },
-  'Education & Academic': {
-    id: 'Education & Academic',
-    name: 'Education & Academic',
+  School: {
+    id: 'School',
+    name: 'School',
     description: 'School trips, academic competitions, and educational events',
     roles: ['Teacher', 'Student', 'Supervisor', 'Coordinator', 'Chaperone'],
     availableTabs: ['roster', 'calendar', 'compliance', 'medical'],


### PR DESCRIPTION
## Summary
- rename `Education & Academic` category to `School`
- update union types and sample data
- adjust role cases for the new category

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cd9aefe8832a926477113336d649