### PR TITLE
Use dynamic roster labels

### DIFF
--- a/src/components/pro/ProTabContent.tsx
+++ b/src/components/pro/ProTabContent.tsx
@@ -9,6 +9,7 @@ import { RosterTab } from './RosterTab';
 import { EquipmentTracking } from './EquipmentTracking';
 import { TripPreferences as TripPreferencesType } from '../../types/consumer';
 import { ProTripData } from '../../types/pro';
+import { ProTripCategory } from '../../types/proCategories';
 import { isReadOnlyTab, hasTabAccess } from './ProTabsConfig';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -18,6 +19,7 @@ interface ProTabContentProps {
   basecamp: { name: string; address: string };
   tripPreferences: TripPreferencesType | undefined;
   tripData: ProTripData;
+  category: ProTripCategory;
   onUpdateRoomAssignments: (assignments: any[]) => void;
   onUpdateEquipment: (equipment: any[]) => void;
 }
@@ -28,6 +30,7 @@ export const ProTabContent = ({
   basecamp,
   tripPreferences,
   tripData,
+  category,
   onUpdateRoomAssignments,
   onUpdateEquipment
 }: ProTabContentProps) => {
@@ -63,6 +66,7 @@ export const ProTabContent = ({
             roster={tripData.roster || []}
             userRole={userRole}
             isReadOnly={isReadOnly}
+            category={category}
           />
         );
       case 'equipment':

--- a/src/components/pro/ProTripDetailContent.tsx
+++ b/src/components/pro/ProTripDetailContent.tsx
@@ -70,6 +70,7 @@ export const ProTripDetailContent = ({
         basecamp={basecamp}
         tripPreferences={tripPreferences}
         tripData={tripData}
+        category={selectedCategory}
         onUpdateRoomAssignments={handleUpdateRoomAssignments}
         onUpdateEquipment={handleUpdateEquipment}
       />

--- a/src/components/pro/RosterTab.tsx
+++ b/src/components/pro/RosterTab.tsx
@@ -1,16 +1,20 @@
 import React, { useState } from 'react';
 import { Users, Shield, Settings, UserCheck, AlertTriangle } from 'lucide-react';
 import { ProParticipant } from '../../types/pro';
+import { ProTripCategory, getCategoryConfig } from '../../types/proCategories';
 
 interface RosterTabProps {
   roster: ProParticipant[];
   userRole: string;
   isReadOnly?: boolean;
+  category: ProTripCategory;
 }
 
-export const RosterTab = ({ roster, userRole, isReadOnly = false }: RosterTabProps) => {
+export const RosterTab = ({ roster, userRole, isReadOnly = false, category }: RosterTabProps) => {
   const [selectedRole, setSelectedRole] = useState<string>('all');
   const [showCredentials, setShowCredentials] = useState(false);
+
+  const { terminology: { teamLabel } } = getCategoryConfig(category);
 
   const roles = ['all', 'Player', 'Coach', 'TourManager', 'Crew', 'VIP', 'Security', 'Medical', 'Tech', 'Producer', 'Talent'];
   
@@ -42,7 +46,7 @@ export const RosterTab = ({ roster, userRole, isReadOnly = false }: RosterTabPro
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <Users className="text-red-400" size={24} />
-            <h2 className="text-xl font-bold text-white">Team Roster</h2>
+            <h2 className="text-xl font-bold text-white">{teamLabel}</h2>
           </div>
           <div className="flex items-center gap-4">
             <span className="text-gray-400">{roster.length} total members</span>


### PR DESCRIPTION
## Summary
- add category prop to `RosterTab`
- have `RosterTab` read the team label from category config
- forward the selected category through `ProTabContent`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf54b128832aaf2c59d825cd8f44