### PR TITLE
Update roster roles to use category config

### DIFF
--- a/src/components/pro/ProTabContent.tsx
+++ b/src/components/pro/ProTabContent.tsx
@@ -9,6 +9,7 @@ import { RosterTab } from './RosterTab';
 import { EquipmentTracking } from './EquipmentTracking';
 import { TripPreferences as TripPreferencesType } from '../../types/consumer';
 import { ProTripData } from '../../types/pro';
+import { ProTripCategory } from '../../types/proCategories';
 import { isReadOnlyTab, hasTabAccess } from './ProTabsConfig';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -63,6 +64,7 @@ export const ProTabContent = ({
             roster={tripData.roster || []}
             userRole={userRole}
             isReadOnly={isReadOnly}
+            category={tripData.proTripCategory as ProTripCategory}
           />
         );
       case 'equipment':

--- a/src/components/pro/RosterTab.tsx
+++ b/src/components/pro/RosterTab.tsx
@@ -1,18 +1,21 @@
 import React, { useState } from 'react';
 import { Users, Shield, Settings, UserCheck, AlertTriangle } from 'lucide-react';
 import { ProParticipant } from '../../types/pro';
+import { ProTripCategory, getCategoryConfig } from '../../types/proCategories';
 
 interface RosterTabProps {
   roster: ProParticipant[];
   userRole: string;
   isReadOnly?: boolean;
+  category: ProTripCategory;
 }
 
-export const RosterTab = ({ roster, userRole, isReadOnly = false }: RosterTabProps) => {
+export const RosterTab = ({ roster, userRole, isReadOnly = false, category }: RosterTabProps) => {
   const [selectedRole, setSelectedRole] = useState<string>('all');
   const [showCredentials, setShowCredentials] = useState(false);
 
-  const roles = ['all', 'Player', 'Coach', 'TourManager', 'Crew', 'VIP', 'Security', 'Medical', 'Tech', 'Producer', 'Talent'];
+  const config = getCategoryConfig(category);
+  const roles = ['all', ...config.roles];
   
   const filteredRoster = selectedRole === 'all' 
     ? roster 


### PR DESCRIPTION
## Summary
- make `RosterTab` accept a category
- load roles from the category configuration and keep `all` first
- pass the trip's category into `RosterTab`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf58bc84832aa00afd8a60930956