### PR TITLE
Use teamLabel for roster tab

### DIFF
--- a/src/components/ProTripCard.tsx
+++ b/src/components/ProTripCard.tsx
@@ -7,6 +7,7 @@ import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { ProTripData } from '../types/pro';
 import { useTripVariant } from '../contexts/TripVariantContext';
+import { getCategoryConfig } from '../types/proCategories';
 
 interface ProTripCardProps {
   trip: ProTripData;
@@ -112,7 +113,9 @@ export const ProTripCard = ({ trip }: ProTripCardProps) => {
           {trip.roster && trip.roster.length > 0 && (
             <div className="flex items-center gap-1 bg-blue-500/20 text-blue-300 px-3 py-1 rounded-full text-xs border border-blue-500/30">
               <Users size={12} />
-              <span>Roster: {trip.roster.length}</span>
+              <span>
+                {getCategoryConfig(trip.category).terminology.teamLabel}: {trip.roster.length}
+              </span>
             </div>
           )}
           {nextLoadIn && (

--- a/src/components/pro/ProTabContent.tsx
+++ b/src/components/pro/ProTabContent.tsx
@@ -18,6 +18,7 @@ interface ProTabContentProps {
   basecamp: { name: string; address: string };
   tripPreferences: TripPreferencesType | undefined;
   tripData: ProTripData;
+  selectedCategory: ProTripCategory;
   onUpdateRoomAssignments: (assignments: any[]) => void;
   onUpdateEquipment: (equipment: any[]) => void;
 }
@@ -28,6 +29,7 @@ export const ProTabContent = ({
   basecamp,
   tripPreferences,
   tripData,
+  selectedCategory,
   onUpdateRoomAssignments,
   onUpdateEquipment
 }: ProTabContentProps) => {
@@ -62,6 +64,7 @@ export const ProTabContent = ({
           <RosterTab
             roster={tripData.roster || []}
             userRole={userRole}
+            category={selectedCategory}
             isReadOnly={isReadOnly}
           />
         );

--- a/src/components/pro/ProTabsConfig.tsx
+++ b/src/components/pro/ProTabsConfig.tsx
@@ -28,17 +28,30 @@ export const proTabs: ProTab[] = [
   { id: 'search', label: 'Search', icon: null }
 ];
 
-export const getVisibleTabs = (userRole: string, userPermissions: string[], category?: ProTripCategory): ProTab[] => {
+export const getVisibleTabs = (
+  userRole: string,
+  userPermissions: string[],
+  category?: ProTripCategory
+): ProTab[] => {
   let availableTabs = proTabs;
-  
+
   // Filter tabs based on category if provided
   if (category) {
     const categoryConfig = getCategoryConfig(category);
-    availableTabs = proTabs.filter(tab => 
-      !tab.proOnly || categoryConfig.availableTabs.includes(tab.id) || ['chat', 'places', 'ai-chat', 'search'].includes(tab.id)
-    );
+    availableTabs = proTabs
+      .filter(
+        tab =>
+          !tab.proOnly ||
+          categoryConfig.availableTabs.includes(tab.id) ||
+          ['chat', 'places', 'ai-chat', 'search'].includes(tab.id)
+      )
+      .map(tab =>
+        tab.id === 'roster'
+          ? { ...tab, label: categoryConfig.terminology.teamLabel }
+          : tab
+      );
   }
-  
+
   return availableTabs.filter(tab => {
     // Check role-based restrictions
     if (tab.restrictedRoles && tab.restrictedRoles.includes(userRole.toLowerCase())) {

--- a/src/components/pro/ProTripDetailContent.tsx
+++ b/src/components/pro/ProTripDetailContent.tsx
@@ -70,6 +70,7 @@ export const ProTripDetailContent = ({
         basecamp={basecamp}
         tripPreferences={tripPreferences}
         tripData={tripData}
+        selectedCategory={selectedCategory}
         onUpdateRoomAssignments={handleUpdateRoomAssignments}
         onUpdateEquipment={handleUpdateEquipment}
       />

--- a/src/components/pro/RosterTab.tsx
+++ b/src/components/pro/RosterTab.tsx
@@ -1,16 +1,20 @@
 import React, { useState } from 'react';
 import { Users, Shield, Settings, UserCheck, AlertTriangle } from 'lucide-react';
 import { ProParticipant } from '../../types/pro';
+import { getCategoryConfig } from '../../types/proCategories';
 
 interface RosterTabProps {
   roster: ProParticipant[];
   userRole: string;
+  category: string;
   isReadOnly?: boolean;
 }
 
-export const RosterTab = ({ roster, userRole, isReadOnly = false }: RosterTabProps) => {
+export const RosterTab = ({ roster, userRole, category, isReadOnly = false }: RosterTabProps) => {
   const [selectedRole, setSelectedRole] = useState<string>('all');
   const [showCredentials, setShowCredentials] = useState(false);
+
+  const teamLabel = getCategoryConfig(category).terminology.teamLabel;
 
   const roles = ['all', 'Player', 'Coach', 'TourManager', 'Crew', 'VIP', 'Security', 'Medical', 'Tech', 'Producer', 'Talent'];
   
@@ -42,7 +46,7 @@ export const RosterTab = ({ roster, userRole, isReadOnly = false }: RosterTabPro
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <Users className="text-red-400" size={24} />
-            <h2 className="text-xl font-bold text-white">Team Roster</h2>
+            <h2 className="text-xl font-bold text-white">{teamLabel}</h2>
           </div>
           <div className="flex items-center gap-4">
             <span className="text-gray-400">{roster.length} total members</span>


### PR DESCRIPTION
## Summary
- map roster tab label to teamLabel from proCategories
- show teamLabel on ProTrip cards
- display teamLabel on roster tab
- pass selectedCategory to roster tab

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf5b57f4832ab9c0b424a00e04f5