### PR TITLE
Ensure role defaults on category change

### DIFF
--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Users, Shield, Star, Play, Wrench, Lock, Heart, Camera, Crown, Building, GraduationCap, Lightbulb } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { Button } from '../ui/button';
@@ -94,6 +94,14 @@ interface RoleSwitcherProps {
 export const RoleSwitcher = ({ category }: RoleSwitcherProps) => {
   const { user, switchRole } = useAuth();
   const config = getCategoryConfig(category);
+
+  useEffect(() => {
+    if (!user?.isPro || !user.proRole) return;
+    const lowerRoles = config.roles.map((r) => r.toLowerCase());
+    if (!lowerRoles.includes(user.proRole)) {
+      switchRole(lowerRoles[0]);
+    }
+  }, [category]);
 
   if (!user?.isPro) return null;
 

--- a/src/components/pro/__tests__/RoleSwitcher.test.tsx
+++ b/src/components/pro/__tests__/RoleSwitcher.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+vi.mock('../../../hooks/useAuth');
+
+import { useAuth } from '../../../hooks/useAuth';
+import { RoleSwitcher } from '../RoleSwitcher';
+
+const mockedUseAuth = vi.mocked(useAuth);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RoleSwitcher', () => {
+  it('switches to first role when current role not in category', async () => {
+    const switchRole = vi.fn();
+    mockedUseAuth.mockReturnValue({
+      user: { isPro: true, proRole: 'admin' },
+      switchRole,
+    } as any);
+
+    render(<RoleSwitcher category="Sports & Athletics" />);
+
+    await waitFor(() => {
+      expect(switchRole).toHaveBeenCalledWith('players');
+    });
+  });
+
+  it('keeps role when valid for category', async () => {
+    const switchRole = vi.fn();
+    mockedUseAuth.mockReturnValue({
+      user: { isPro: true, proRole: 'players' },
+      switchRole,
+    } as any);
+
+    render(<RoleSwitcher category="Sports & Athletics" />);
+
+    await waitFor(() => {
+      expect(switchRole).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- switch user role to match selected category when needed
- add tests for new RoleSwitcher behavior

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf61af60832ab7b9db8bb070ad0f