### PR TITLE
Rename TV/Film Production category

### DIFF
--- a/src/components/EnterpriseSettings.tsx
+++ b/src/components/EnterpriseSettings.tsx
@@ -228,7 +228,7 @@ export const EnterpriseSettings = ({ organizationId, currentUserId, defaultSecti
     { value: 'recruit', label: 'Recruiting Trip' },
     { value: 'biz', label: 'Business Travel (Sales / Exec)' },
     { value: 'field', label: 'School Field Trip' },
-    { value: 'film', label: 'Film / TV Production' },
+    { value: 'film', label: 'Content' },
     { value: 'nonprofit', label: 'Non-Profit Mission (Humanitarian)' }
   ];
 

--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -32,7 +32,7 @@ const getRoleIcon = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('student')) return Users;
       return Shield;
     
-    case 'TV/Film Production':
+    case 'Content':
       if (lowerRole.includes('cast') || lowerRole.includes('talent')) return Star;
       if (lowerRole.includes('producer') || lowerRole.includes('director')) return Camera;
       return Wrench;
@@ -72,7 +72,7 @@ const getRoleColor = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('student')) return 'bg-green-500';
       return 'bg-gray-500';
     
-    case 'TV/Film Production':
+    case 'Content':
       if (lowerRole.includes('cast')) return 'bg-yellow-500';
       if (lowerRole.includes('producer')) return 'bg-red-500';
       return 'bg-gray-500';

--- a/src/types/pro.ts
+++ b/src/types/pro.ts
@@ -296,7 +296,7 @@ export interface ProTripData {
     | 'Music & Entertainment Tours'
     | 'Corporate & Business'
     | 'School'
-    | 'TV/Film Production'
+    | 'Content'
     | 'Startup & Tech';
   tags: string[];
   participants: ProTripParticipant[];

--- a/src/types/proCategories.ts
+++ b/src/types/proCategories.ts
@@ -6,7 +6,7 @@ export type ProTripCategory =
   | 'Music & Entertainment Tours'
   | 'Corporate & Business'
   | 'School'
-  | 'TV/Film Production'
+  | 'Content'
   | 'Startup & Tech';
 
 export interface ProCategoryConfig {
@@ -76,9 +76,9 @@ export const PRO_CATEGORY_CONFIGS: Record<ProTripCategory, ProCategoryConfig> = 
       leaderLabel: 'Lead Teacher'
     }
   },
-  'TV/Film Production': {
-    id: 'TV/Film Production',
-    name: 'TV/Film Production',
+  Content: {
+    id: 'Content',
+    name: 'Content',
     description: 'Television shows, film productions, and media shoots',
     roles: ['Cast', 'Producers', 'Directors', 'Crew', 'Script Supervisors', 'Camera Operators'],
     availableTabs: ['roster', 'equipment', 'calendar', 'media', 'sponsors', 'compliance'],


### PR DESCRIPTION
## Summary
- rename the pro trip category `TV/Film Production` to `Content`
- update type unions and config
- switch on the new `Content` category in RoleSwitcher
- adjust dropdown text in EnterpriseSettings

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e4f3d8c4832a877c3aab8d869f68