### PR TITLE
Rename TV/Film Production to Content

### DIFF
--- a/src/components/EnterpriseSettings.tsx
+++ b/src/components/EnterpriseSettings.tsx
@@ -228,7 +228,7 @@ export const EnterpriseSettings = ({ organizationId, currentUserId, defaultSecti
     { value: 'recruit', label: 'Recruiting Trip' },
     { value: 'biz', label: 'Business Travel (Sales / Exec)' },
     { value: 'field', label: 'School Field Trip' },
-    { value: 'film', label: 'Film / TV Production' },
+    { value: 'film', label: 'Content' },
     { value: 'nonprofit', label: 'Non-Profit Mission (Humanitarian)' }
   ];
 

--- a/src/components/pro/ProTabsConfig.tsx
+++ b/src/components/pro/ProTabsConfig.tsx
@@ -16,7 +16,7 @@ export interface ProTab {
 export const proTabs: ProTab[] = [
   { id: 'chat', label: 'Chat', icon: null },
   { id: 'places', label: 'Places', icon: null },
-  { id: 'roster', label: 'Roster', icon: Users, proOnly: true, requiredPermissions: ['read'] },
+  { id: 'roster', label: 'Cast', icon: Users, proOnly: true, requiredPermissions: ['read'] },
   { id: 'equipment', label: 'Equipment', icon: Package, proOnly: true, requiredPermissions: ['read'] },
   { id: 'calendar', label: 'Calendar', icon: CalendarIcon, proOnly: true, requiredPermissions: ['read'] },
   { id: 'finance', label: 'Finance', icon: DollarSign, proOnly: true, restrictedRoles: ['talent', 'cast', 'student'], requiredPermissions: ['finance'] },

--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -32,7 +32,7 @@ const getRoleIcon = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('student')) return Users;
       return Shield;
     
-    case 'TV/Film Production':
+    case 'Content':
       if (lowerRole.includes('cast') || lowerRole.includes('talent')) return Star;
       if (lowerRole.includes('producer') || lowerRole.includes('director')) return Camera;
       return Wrench;
@@ -72,7 +72,7 @@ const getRoleColor = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('student')) return 'bg-green-500';
       return 'bg-gray-500';
     
-    case 'TV/Film Production':
+    case 'Content':
       if (lowerRole.includes('cast')) return 'bg-yellow-500';
       if (lowerRole.includes('producer')) return 'bg-red-500';
       return 'bg-gray-500';

--- a/src/data/pro-trips/realHousewivesAtlShoot.ts
+++ b/src/data/pro-trips/realHousewivesAtlShoot.ts
@@ -6,12 +6,12 @@ export const realHousewivesAtlShoot: ProTripData = {
   description: 'Reality TV production shoot for Real Housewives of Atlanta Season 9 cast and crew.',
   location: 'Atlanta GA',
   dateRange: 'Aug 1 - Sep 30, 2025',
-  category: 'TV Production',
-  tags: ['TV Production', 'Reality Show', 'Cast & Crew'],
+  category: 'Content',
+  tags: ['Content', 'Reality Show', 'Cast & Crew'],
   participants: [
     { id: 27, name: 'Kenya Moore', avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=40&h=40&fit=crop&crop=face', role: 'Cast' },
     { id: 28, name: 'Executive Producer', avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face', role: 'Producers' },
-    { id: 29, name: 'Camera Operator', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face', role: 'Camera Operators' },
+    { id: 29, name: 'Camera Operator', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face', role: 'Crew' },
     { id: 30, name: 'Production Assistant', avatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=40&h=40&fit=crop&crop=face', role: 'Crew' }
   ],
   budget: {
@@ -63,7 +63,7 @@ export const realHousewivesAtlShoot: ProTripData = {
       name: 'Camera Operator',
       email: 'camera@bravotv.com',
       avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face',
-      role: 'Camera Operators',
+      role: 'Crew',
       credentialLevel: 'Backstage',
       permissions: ['filming-areas', 'equipment-access'],
       roomPreferences: ['crew-housing'],
@@ -147,7 +147,7 @@ export const realHousewivesAtlShoot: ProTripData = {
     {
       id: 'comp-rh1',
       type: 'safety',
-      title: 'TV Production Safety Compliance',
+      title: 'Content Safety Compliance',
       description: 'All crew must complete safety training and background checks',
       deadline: '2025-07-25',
       status: 'compliant',

--- a/src/types/pro.ts
+++ b/src/types/pro.ts
@@ -296,7 +296,7 @@ export interface ProTripData {
     | 'Music & Entertainment Tours'
     | 'Corporate & Business'
     | 'School'
-    | 'TV/Film Production'
+    | 'Content'
     | 'Startup & Tech';
   tags: string[];
   participants: ProTripParticipant[];

--- a/src/types/proCategories.ts
+++ b/src/types/proCategories.ts
@@ -6,7 +6,7 @@ export type ProTripCategory =
   | 'Music & Entertainment Tours'
   | 'Corporate & Business'
   | 'School'
-  | 'TV/Film Production'
+  | 'Content'
   | 'Startup & Tech';
 
 export interface ProCategoryConfig {
@@ -76,11 +76,11 @@ export const PRO_CATEGORY_CONFIGS: Record<ProTripCategory, ProCategoryConfig> = 
       leaderLabel: 'Lead Teacher'
     }
   },
-  'TV/Film Production': {
-    id: 'TV/Film Production',
-    name: 'TV/Film Production',
-    description: 'Television shows, film productions, and media shoots',
-    roles: ['Cast', 'Producers', 'Directors', 'Crew', 'Script Supervisors', 'Camera Operators'],
+  Content: {
+    id: 'Content',
+    name: 'Content',
+    description: 'Film, television, and online media productions',
+    roles: ['Cast', 'Producers', 'Directors', 'Crew', 'Writing Team', 'Logistics Coordinators'],
     availableTabs: ['roster', 'equipment', 'calendar', 'media', 'sponsors', 'compliance'],
     requiredTabs: ['roster', 'equipment'],
     terminology: {


### PR DESCRIPTION
## Summary
- rename `TV/Film Production` category to `Content`
- update role options and labels for the new category
- change tab label from **Roster** to **Cast**
- adjust sample data and enterprise settings wording

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dcda6db0832ab1c9747039ed0a4c