### PR TITLE
Add category prop to ProTabNavigation

### DIFF
--- a/src/components/pro/ProTabNavigation.tsx
+++ b/src/components/pro/ProTabNavigation.tsx
@@ -4,14 +4,16 @@ import { Crown, Lock } from 'lucide-react';
 import { useTripVariant } from '../../contexts/TripVariantContext';
 import { useAuth } from '../../hooks/useAuth';
 import { ProTab, isReadOnlyTab } from './ProTabsConfig';
+import { ProTripCategory } from '../../types/proCategories';
 
 interface ProTabNavigationProps {
   tabs: ProTab[];
   activeTab: string;
   onTabChange: (tab: string) => void;
+  category: ProTripCategory;
 }
 
-export const ProTabNavigation = ({ tabs, activeTab, onTabChange }: ProTabNavigationProps) => {
+export const ProTabNavigation = ({ tabs, activeTab, onTabChange, category }: ProTabNavigationProps) => {
   const { accentColors } = useTripVariant();
   const { user } = useAuth();
 
@@ -23,6 +25,8 @@ export const ProTabNavigation = ({ tabs, activeTab, onTabChange }: ProTabNavigat
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isReadOnly = isReadOnlyTab(tab.id, userRole, userPermissions);
+        const displayLabel =
+          tab.id === 'roster' && category === 'Content' ? 'Cast' : tab.label;
         
         return (
           <button
@@ -35,7 +39,7 @@ export const ProTabNavigation = ({ tabs, activeTab, onTabChange }: ProTabNavigat
             } ${isReadOnly ? 'opacity-75' : ''}`}
           >
             {Icon && <Icon size={16} />}
-            {tab.label}
+            {displayLabel}
             {tab.proOnly && (
               <Crown size={14} className={`text-${accentColors.primary}`} />
             )}

--- a/src/components/pro/ProTripDetailContent.tsx
+++ b/src/components/pro/ProTripDetailContent.tsx
@@ -61,6 +61,7 @@ export const ProTripDetailContent = ({
         tabs={visibleTabs}
         activeTab={activeTab}
         onTabChange={onTabChange}
+        category={selectedCategory}
       />
 
       {/* Tab Content */}


### PR DESCRIPTION
## Summary
- allow `ProTabNavigation` to receive the trip category
- show "Cast" label on roster tab when the category is `Content`
- forward the selected category from `ProTripDetailContent`

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6866e86ab198832a92e793c94546d059