### PR TITLE
Update roles for content category

### DIFF
--- a/src/data/pro-trips/realHousewivesAtlShoot.ts
+++ b/src/data/pro-trips/realHousewivesAtlShoot.ts
@@ -11,7 +11,7 @@ export const realHousewivesAtlShoot: ProTripData = {
   participants: [
     { id: 27, name: 'Kenya Moore', avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=40&h=40&fit=crop&crop=face', role: 'Cast' },
     { id: 28, name: 'Executive Producer', avatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face', role: 'Producers' },
-    { id: 29, name: 'Camera Operator', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face', role: 'Camera Operators' },
+    { id: 29, name: 'Camera Operator', avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face', role: 'Crew' },
     { id: 30, name: 'Production Assistant', avatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=40&h=40&fit=crop&crop=face', role: 'Crew' }
   ],
   budget: {
@@ -63,7 +63,7 @@ export const realHousewivesAtlShoot: ProTripData = {
       name: 'Camera Operator',
       email: 'camera@bravotv.com',
       avatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face',
-      role: 'Camera Operators',
+      role: 'Crew',
       credentialLevel: 'Backstage',
       permissions: ['filming-areas', 'equipment-access'],
       roomPreferences: ['crew-housing'],

--- a/src/types/proCategories.ts
+++ b/src/types/proCategories.ts
@@ -80,7 +80,7 @@ export const PRO_CATEGORY_CONFIGS: Record<ProTripCategory, ProCategoryConfig> = 
     id: 'Content',
     name: 'Content',
     description: 'Television shows, film productions, and media shoots',
-    roles: ['Cast', 'Producers', 'Directors', 'Crew', 'Script Supervisors', 'Camera Operators'],
+    roles: ['Cast', 'Producers', 'Directors', 'Crew', 'Writing Team', 'Logistics Coordinators'],
     availableTabs: ['roster', 'equipment', 'calendar', 'media', 'sponsors', 'compliance'],
     requiredTabs: ['roster', 'equipment'],
     terminology: {


### PR DESCRIPTION
## Summary
- change TV category roles to Crew-centric names
- fix sample data to use `Crew` instead of `Camera Operators`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e853e840832aaa92f6d11da732a9