### PR TITLE
Adjust role switcher for events

### DIFF
--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -1,6 +1,21 @@
 
 import React, { useEffect } from 'react';
-import { Users, Shield, Star, Play, Wrench, Lock, Heart, Camera, Crown, Building, GraduationCap, Lightbulb } from 'lucide-react';
+import {
+  Users,
+  Shield,
+  Star,
+  Play,
+  Wrench,
+  Lock,
+  Heart,
+  Camera,
+  Crown,
+  Building,
+  GraduationCap,
+  Mic,
+  User,
+  Truck,
+} from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { Button } from '../ui/button';
 import { ProTripCategory, getCategoryConfig } from '../../types/proCategories';
@@ -37,9 +52,11 @@ const getRoleIcon = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('producer') || lowerRole.includes('director')) return Camera;
       return Wrench;
     
-    case 'Startup & Tech':
-      if (lowerRole.includes('founder')) return Lightbulb;
-      if (lowerRole.includes('mentor')) return GraduationCap;
+    case 'Events':
+      if (lowerRole.includes('speaker')) return Mic;
+      if (lowerRole.includes('guest')) return User;
+      if (lowerRole.includes('logistics')) return Truck;
+      if (lowerRole.includes('press')) return Camera;
       return Users;
     
     default:
@@ -77,9 +94,11 @@ const getRoleColor = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('producer')) return 'bg-red-500';
       return 'bg-gray-500';
     
-    case 'Startup & Tech':
-      if (lowerRole.includes('founder')) return 'bg-yellow-500';
-      if (lowerRole.includes('mentor')) return 'bg-blue-500';
+    case 'Events':
+      if (lowerRole.includes('speaker')) return 'bg-yellow-500';
+      if (lowerRole.includes('guest')) return 'bg-green-500';
+      if (lowerRole.includes('logistics')) return 'bg-blue-500';
+      if (lowerRole.includes('press')) return 'bg-red-500';
       return 'bg-gray-500';
     
     default:


### PR DESCRIPTION
## Summary
- rename the Startup & Tech case in `RoleSwitcher` to `Events`
- recognize new role keywords speaker, guest, logistics, and press
- remove logic for founder and mentor
- add new icons for event roles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866f3555cbc832a90f3648afecf5bb3