### PR TITLE
Update Events category roles

### DIFF
--- a/src/components/pro/RoleSwitcher.tsx
+++ b/src/components/pro/RoleSwitcher.tsx
@@ -37,9 +37,11 @@ const getRoleIcon = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('producer') || lowerRole.includes('director')) return Camera;
       return Wrench;
     
-    case 'Startup & Tech':
-      if (lowerRole.includes('founder')) return Lightbulb;
-      if (lowerRole.includes('mentor')) return GraduationCap;
+    case 'Events':
+      if (lowerRole.includes('speaker')) return Star;
+      if (lowerRole.includes('coordinator')) return Users;
+      if (lowerRole.includes('logistics')) return Wrench;
+      if (lowerRole.includes('press')) return Camera;
       return Users;
     
     default:
@@ -77,9 +79,11 @@ const getRoleColor = (role: string, category: ProTripCategory) => {
       if (lowerRole.includes('producer')) return 'bg-red-500';
       return 'bg-gray-500';
     
-    case 'Startup & Tech':
-      if (lowerRole.includes('founder')) return 'bg-yellow-500';
-      if (lowerRole.includes('mentor')) return 'bg-blue-500';
+    case 'Events':
+      if (lowerRole.includes('speaker')) return 'bg-yellow-500';
+      if (lowerRole.includes('coordinator')) return 'bg-blue-500';
+      if (lowerRole.includes('logistics')) return 'bg-red-500';
+      if (lowerRole.includes('press')) return 'bg-purple-500';
       return 'bg-gray-500';
     
     default:

--- a/src/data/pro-trips/yCombinatorCohort.ts
+++ b/src/data/pro-trips/yCombinatorCohort.ts
@@ -7,7 +7,7 @@ export const yCombinatorCohort: ProTripData = {
   location: 'San Francisco CA',
   dateRange: 'Feb 1 - Mar 31, 2025',
   category: 'Startup',
-  proTripCategory: 'Startup & Tech',
+  proTripCategory: 'Events',
   tags: ['Startup', 'Accelerator', 'Demo Day'],
   participants: [
     { id: 24, name: 'Jessica Chen', avatar: 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=40&h=40&fit=crop&crop=face', role: 'Founders' },

--- a/src/types/pro.ts
+++ b/src/types/pro.ts
@@ -297,7 +297,7 @@ export interface ProTripData {
     | 'Corporate & Business'
     | 'School'
     | 'Content'
-    | 'Startup & Tech';
+    | 'Events';
   tags: string[];
   participants: ProTripParticipant[];
   budget: {

--- a/src/types/proCategories.ts
+++ b/src/types/proCategories.ts
@@ -7,7 +7,7 @@ export type ProTripCategory =
   | 'Corporate & Business'
   | 'School'
   | 'Content'
-  | 'Startup & Tech';
+  | 'Events';
 
 export interface ProCategoryConfig {
   id: ProTripCategory;
@@ -89,17 +89,17 @@ export const PRO_CATEGORY_CONFIGS: Record<ProTripCategory, ProCategoryConfig> = 
       leaderLabel: 'Producer'
     }
   },
-  'Startup & Tech': {
-    id: 'Startup & Tech',
-    name: 'Startup & Tech',
-    description: 'Accelerator programs, tech conferences, and startup events',
-    roles: ['Founders', 'Mentors', 'Coordinators', 'Investors', 'Advisors'],
+  Events: {
+    id: 'Events',
+    name: 'Events',
+    description: 'Accelerator programs, tech conferences, and other events',
+    roles: ['Speakers', 'Guests', 'Coordinators', 'Logistics', 'Press'],
     availableTabs: ['roster', 'calendar', 'finance'],
     requiredTabs: ['roster'],
     terminology: {
       teamLabel: 'Team',
       memberLabel: 'Team Member',
-      leaderLabel: 'Founder'
+      leaderLabel: 'Event Lead'
     }
   }
 };


### PR DESCRIPTION
## Summary
- rename `Startup & Tech` category to `Events`
- update the events category roles and terminology
- adjust union types and usage across app
- update role switcher icons and colours

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f3547da4832a9e975757be5a4d53