### PR TITLE
Extend pro roles

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,7 +9,20 @@ interface User {
   avatar?: string;
   isPro: boolean;
   // Enhanced pro role system
-  proRole?: 'admin' | 'staff' | 'talent' | 'player' | 'crew' | 'security' | 'medical' | 'producer';
+  proRole?:
+    | 'admin'
+    | 'staff'
+    | 'talent'
+    | 'player'
+    | 'crew'
+    | 'security'
+    | 'medical'
+    | 'producer'
+    | 'speakers'
+    | 'guests'
+    | 'coordinators'
+    | 'logistics'
+    | 'press';
   organizationId?: string;
   permissions: string[];
   notificationSettings: {
@@ -143,7 +156,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         crew: ['read', 'write'],
         security: ['read', 'write'],
         medical: ['read', 'write', 'medical'],
-        producer: ['read', 'write', 'admin']
+        producer: ['read', 'write', 'admin'],
+        speakers: ['read'],
+        guests: ['read'],
+        coordinators: ['read', 'write'],
+        logistics: ['read', 'write'],
+        press: ['read', 'write']
       };
       
       setUser({


### PR DESCRIPTION
## Summary
- expand `User['proRole']` in `useAuth` to handle speakers, guests, coordinators, logistics and press
- map new roles in `switchRole` permissions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f3576e50832a90a70616aed32fce