### PR TITLE
Add new pro roles

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,7 +9,20 @@ interface User {
   avatar?: string;
   isPro: boolean;
   // Enhanced pro role system
-  proRole?: 'admin' | 'staff' | 'talent' | 'player' | 'crew' | 'security' | 'medical' | 'producer';
+  proRole?:
+    | 'admin'
+    | 'staff'
+    | 'talent'
+    | 'player'
+    | 'crew'
+    | 'security'
+    | 'medical'
+    | 'producer'
+    | 'speakers'
+    | 'guests'
+    | 'coordinators'
+    | 'logistics'
+    | 'press';
   organizationId?: string;
   permissions: string[];
   notificationSettings: {
@@ -143,7 +156,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         crew: ['read', 'write'],
         security: ['read', 'write'],
         medical: ['read', 'write', 'medical'],
-        producer: ['read', 'write', 'admin']
+        producer: ['read', 'write', 'admin'],
+        speakers: ['read'],
+        guests: ['read'],
+        coordinators: ['read', 'write'],
+        logistics: ['read', 'write'],
+        press: ['read']
       };
       
       setUser({


### PR DESCRIPTION
## Summary
- extend `User['proRole']` union with speakers, guests, coordinators, logistics and press
- assign default permissions for new roles in `switchRole`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f56140c0832a8be7affc7f257e96