### PR TITLE
Add recipient selector to broadcasts

### DIFF
--- a/src/components/BroadcastComposer.tsx
+++ b/src/components/BroadcastComposer.tsx
@@ -1,21 +1,32 @@
 
 import React, { useState } from 'react';
-import { Send, MapPin, Clock } from 'lucide-react';
+import { Send, MapPin } from 'lucide-react';
 import { Button } from './ui/button';
 
+interface Participant {
+  id: string | number;
+  name: string;
+  role: string;
+}
+
 interface BroadcastComposerProps {
+  participants: Participant[];
   onSend: (broadcast: {
     message: string;
     location?: string;
     category: 'chill' | 'logistics' | 'urgent';
+    recipients: string;
   }) => void;
 }
 
-export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
+export const BroadcastComposer = ({ participants, onSend }: BroadcastComposerProps) => {
   const [message, setMessage] = useState('');
   const [location, setLocation] = useState('');
   const [category, setCategory] = useState<'chill' | 'logistics' | 'urgent'>('chill');
   const [showDetails, setShowDetails] = useState(false);
+  const [recipient, setRecipient] = useState('everyone');
+
+  const roleOptions = Array.from(new Set(participants.map(p => p.role)));
 
   const handleSend = () => {
     if (!message.trim()) return;
@@ -23,13 +34,15 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
     onSend({
       message: message.trim(),
       location: location.trim() || undefined,
-      category
+      category,
+      recipients: recipient
     });
 
     // Reset form
     setMessage('');
     setLocation('');
     setCategory('chill');
+    setRecipient('everyone');
     setShowDetails(false);
   };
 
@@ -73,6 +86,25 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
             </div>
             
             <div className="flex items-center gap-2">
+              {/* Recipient selector */}
+              <select
+                value={recipient}
+                onChange={(e) => setRecipient(e.target.value)}
+                className="bg-slate-700 text-white text-xs rounded px-2 py-1"
+              >
+                <option value="everyone">Everyone</option>
+                {roleOptions.map((role) => (
+                  <option key={`role-${role}`} value={`role:${role}`}>
+                    {role}
+                  </option>
+                ))}
+                {participants.map((p) => (
+                  <option key={`user-${p.id}`} value={`user:${p.id}`}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+
               {/* Category selector */}
               <div className="flex gap-1">
                 {(['chill', 'logistics', 'urgent'] as const).map((cat) => (

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -3,6 +3,9 @@ import React, { useState } from 'react';
 import { Broadcast } from './Broadcast';
 import { BroadcastComposer } from './BroadcastComposer';
 import { Radio, Clock } from 'lucide-react';
+import { taylorSwiftErasTour } from '../data/pro-trips/taylorSwiftErasTour';
+
+const participants = taylorSwiftErasTour.participants;
 
 interface BroadcastData {
   id: string;
@@ -11,6 +14,7 @@ interface BroadcastData {
   timestamp: Date;
   location?: string;
   category: 'chill' | 'logistics' | 'urgent';
+  recipients: string;
   responses: {
     coming: number;
     wait: number;
@@ -26,6 +30,7 @@ const mockBroadcasts: BroadcastData[] = [
     message: 'Heading to the pool in 10 minutes! Join us if you want 🏊‍♀️',
     timestamp: new Date(Date.now() - 15 * 60 * 1000), // 15 minutes ago
     location: 'Hotel Pool',
+    recipients: 'everyone',
     category: 'chill',
     responses: { coming: 3, wait: 1, cant: 0 }
   },
@@ -35,6 +40,7 @@ const mockBroadcasts: BroadcastData[] = [
     message: 'Dinner reservation confirmed for 7:45 PM at Le Petit Bistro. Don\'t be late!',
     timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
     location: 'Le Petit Bistro',
+    recipients: 'everyone',
     category: 'logistics',
     responses: { coming: 5, wait: 0, cant: 1 }
   },
@@ -43,6 +49,7 @@ const mockBroadcasts: BroadcastData[] = [
     sender: 'Sarah',
     message: 'Last shuttle back to hotel leaves at 1:30 AM - don\'t miss it!!',
     timestamp: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+    recipients: 'everyone',
     category: 'urgent',
     responses: { coming: 6, wait: 0, cant: 0 }
   }
@@ -56,6 +63,7 @@ export const Broadcasts = () => {
     message: string;
     location?: string;
     category: 'chill' | 'logistics' | 'urgent';
+    recipients: string;
   }) => {
     const broadcast: BroadcastData = {
       id: Date.now().toString(),
@@ -64,6 +72,7 @@ export const Broadcasts = () => {
       timestamp: new Date(),
       location: newBroadcast.location,
       category: newBroadcast.category,
+      recipients: newBroadcast.recipients,
       responses: { coming: 0, wait: 0, cant: 0 }
     };
 
@@ -116,7 +125,7 @@ export const Broadcasts = () => {
       </div>
 
       {/* Broadcast Composer */}
-      <BroadcastComposer onSend={handleNewBroadcast} />
+      <BroadcastComposer participants={participants} onSend={handleNewBroadcast} />
 
       {/* Active Broadcasts */}
       <div className="space-y-4">


### PR DESCRIPTION
## Summary
- extend `BroadcastComposer` with a recipient dropdown
- feed participant data to the composer from `Broadcasts`
- include selected recipients in new broadcasts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68670b9f5a44832a9a81e893e7239dd0