### PR TITLE
Fix duplicate recipients for broadcasts

### DIFF
--- a/src/components/BroadcastComposer.tsx
+++ b/src/components/BroadcastComposer.tsx
@@ -1,20 +1,22 @@
-
-import React, { useState } from 'react';
-import { Send, MapPin, Clock } from 'lucide-react';
-import { Button } from './ui/button';
+import React, { useState } from "react";
+import { Send, MapPin, Clock } from "lucide-react";
+import { Button } from "./ui/button";
 
 interface BroadcastComposerProps {
   onSend: (broadcast: {
     message: string;
     location?: string;
-    category: 'chill' | 'logistics' | 'urgent';
+    category: "chill" | "logistics" | "urgent";
+    recipients?: string[];
   }) => void;
 }
 
 export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
-  const [message, setMessage] = useState('');
-  const [location, setLocation] = useState('');
-  const [category, setCategory] = useState<'chill' | 'logistics' | 'urgent'>('chill');
+  const [message, setMessage] = useState("");
+  const [location, setLocation] = useState("");
+  const [category, setCategory] = useState<"chill" | "logistics" | "urgent">(
+    "chill",
+  );
   const [showDetails, setShowDetails] = useState(false);
 
   const handleSend = () => {
@@ -23,22 +25,27 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
     onSend({
       message: message.trim(),
       location: location.trim() || undefined,
-      category
+      category,
+      recipients: [],
     });
 
     // Reset form
-    setMessage('');
-    setLocation('');
-    setCategory('chill');
+    setMessage("");
+    setLocation("");
+    setCategory("chill");
     setShowDetails(false);
   };
 
   const getCategoryColor = (cat: string) => {
     switch (cat) {
-      case 'chill': return 'bg-blue-600';
-      case 'logistics': return 'bg-yellow-600';
-      case 'urgent': return 'bg-red-600';
-      default: return 'bg-slate-600';
+      case "chill":
+        return "bg-blue-600";
+      case "logistics":
+        return "bg-yellow-600";
+      case "urgent":
+        return "bg-red-600";
+      default:
+        return "bg-slate-600";
     }
   };
 
@@ -57,7 +64,7 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
             rows={2}
             className="w-full bg-slate-900/50 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-500 resize-none"
           />
-          
+
           <div className="flex items-center justify-between mt-3">
             <div className="flex items-center gap-2">
               <button
@@ -71,25 +78,25 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
                 {message.length}/140
               </span>
             </div>
-            
+
             <div className="flex items-center gap-2">
               {/* Category selector */}
               <div className="flex gap-1">
-                {(['chill', 'logistics', 'urgent'] as const).map((cat) => (
+                {(["chill", "logistics", "urgent"] as const).map((cat) => (
                   <button
                     key={cat}
                     onClick={() => setCategory(cat)}
                     className={`px-2 py-1 rounded text-xs font-medium transition-colors ${
                       category === cat
                         ? `${getCategoryColor(cat)} text-white`
-                        : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+                        : "bg-slate-700 text-slate-300 hover:bg-slate-600"
                     }`}
                   >
                     {cat}
                   </button>
                 ))}
               </div>
-              
+
               <Button
                 onClick={handleSend}
                 disabled={!message.trim()}

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -1,8 +1,7 @@
-
-import React, { useState } from 'react';
-import { Broadcast } from './Broadcast';
-import { BroadcastComposer } from './BroadcastComposer';
-import { Radio, Clock } from 'lucide-react';
+import React, { useState } from "react";
+import { Broadcast } from "./Broadcast";
+import { BroadcastComposer } from "./BroadcastComposer";
+import { Radio, Clock } from "lucide-react";
 
 interface BroadcastData {
   id: string;
@@ -10,98 +9,114 @@ interface BroadcastData {
   message: string;
   timestamp: Date;
   location?: string;
-  category: 'chill' | 'logistics' | 'urgent';
+  category: "chill" | "logistics" | "urgent";
+  recipients?: string[];
   responses: {
     coming: number;
     wait: number;
     cant: number;
   };
-  userResponse?: 'coming' | 'wait' | 'cant';
+  userResponse?: "coming" | "wait" | "cant";
 }
 
 const mockBroadcasts: BroadcastData[] = [
   {
-    id: '1',
-    sender: 'Emma',
-    message: 'Heading to the pool in 10 minutes! Join us if you want 🏊‍♀️',
+    id: "1",
+    sender: "Emma",
+    message: "Heading to the pool in 10 minutes! Join us if you want 🏊‍♀️",
     timestamp: new Date(Date.now() - 15 * 60 * 1000), // 15 minutes ago
-    location: 'Hotel Pool',
-    category: 'chill',
-    responses: { coming: 3, wait: 1, cant: 0 }
+    location: "Hotel Pool",
+    category: "chill",
+    responses: { coming: 3, wait: 1, cant: 0 },
   },
   {
-    id: '2',
-    sender: 'Jake',
-    message: 'Dinner reservation confirmed for 7:45 PM at Le Petit Bistro. Don\'t be late!',
+    id: "2",
+    sender: "Jake",
+    message:
+      "Dinner reservation confirmed for 7:45 PM at Le Petit Bistro. Don't be late!",
     timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
-    location: 'Le Petit Bistro',
-    category: 'logistics',
-    responses: { coming: 5, wait: 0, cant: 1 }
+    location: "Le Petit Bistro",
+    category: "logistics",
+    responses: { coming: 5, wait: 0, cant: 1 },
   },
   {
-    id: '3',
-    sender: 'Sarah',
-    message: 'Last shuttle back to hotel leaves at 1:30 AM - don\'t miss it!!',
+    id: "3",
+    sender: "Sarah",
+    message: "Last shuttle back to hotel leaves at 1:30 AM - don't miss it!!",
     timestamp: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
-    category: 'urgent',
-    responses: { coming: 6, wait: 0, cant: 0 }
-  }
+    category: "urgent",
+    responses: { coming: 6, wait: 0, cant: 0 },
+  },
 ];
 
 export const Broadcasts = () => {
   const [broadcasts, setBroadcasts] = useState<BroadcastData[]>(mockBroadcasts);
-  const [userResponses, setUserResponses] = useState<Record<string, 'coming' | 'wait' | 'cant'>>({});
+  const [userResponses, setUserResponses] = useState<
+    Record<string, "coming" | "wait" | "cant">
+  >({});
 
   const handleNewBroadcast = (newBroadcast: {
     message: string;
     location?: string;
-    category: 'chill' | 'logistics' | 'urgent';
+    category: "chill" | "logistics" | "urgent";
+    recipients?: string[];
   }) => {
+    const uniqueRecipients = Array.from(new Set(newBroadcast.recipients ?? []));
     const broadcast: BroadcastData = {
       id: Date.now().toString(),
-      sender: 'You',
+      sender: "You",
       message: newBroadcast.message,
       timestamp: new Date(),
       location: newBroadcast.location,
       category: newBroadcast.category,
-      responses: { coming: 0, wait: 0, cant: 0 }
+      recipients: uniqueRecipients,
+      responses: { coming: 0, wait: 0, cant: 0 },
     };
 
     setBroadcasts([broadcast, ...broadcasts]);
   };
 
-  const handleResponse = (broadcastId: string, response: 'coming' | 'wait' | 'cant') => {
+  const handleResponse = (
+    broadcastId: string,
+    response: "coming" | "wait" | "cant",
+  ) => {
     const prevResponse = userResponses[broadcastId];
-    
-    setBroadcasts(broadcasts.map(broadcast => {
-      if (broadcast.id === broadcastId) {
-        const newResponses = { ...broadcast.responses };
-        
-        // Remove previous response
-        if (prevResponse) {
-          newResponses[prevResponse] = Math.max(0, newResponses[prevResponse] - 1);
+
+    setBroadcasts(
+      broadcasts.map((broadcast) => {
+        if (broadcast.id === broadcastId) {
+          const newResponses = { ...broadcast.responses };
+
+          // Remove previous response
+          if (prevResponse) {
+            newResponses[prevResponse] = Math.max(
+              0,
+              newResponses[prevResponse] - 1,
+            );
+          }
+
+          // Add new response
+          newResponses[response] = newResponses[response] + 1;
+
+          return {
+            ...broadcast,
+            responses: newResponses,
+          };
         }
-        
-        // Add new response
-        newResponses[response] = newResponses[response] + 1;
-        
-        return {
-          ...broadcast,
-          responses: newResponses
-        };
-      }
-      return broadcast;
-    }));
+        return broadcast;
+      }),
+    );
 
     setUserResponses({
       ...userResponses,
-      [broadcastId]: response
+      [broadcastId]: response,
     });
   };
 
   // Filter broadcasts from last 48 hours
-  const recentBroadcasts = broadcasts.filter(broadcast => {
-    const hoursDiff = (Date.now() - broadcast.timestamp.getTime()) / (1000 * 60 * 60);
+  const recentBroadcasts = broadcasts.filter((broadcast) => {
+    const hoursDiff =
+      (Date.now() - broadcast.timestamp.getTime()) / (1000 * 60 * 60);
     return hoursDiff <= 48;
   });
 
@@ -111,7 +126,9 @@ export const Broadcasts = () => {
         <Radio size={24} className="text-blue-400" />
         <div>
           <h2 className="text-xl font-semibold text-white">Broadcasts</h2>
-          <p className="text-slate-400 text-sm">Quick updates and alerts for the group</p>
+          <p className="text-slate-400 text-sm">
+            Quick updates and alerts for the group
+          </p>
         </div>
       </div>
 
@@ -132,7 +149,9 @@ export const Broadcasts = () => {
         ) : (
           <div className="text-center py-12">
             <Radio size={48} className="text-slate-600 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-slate-400 mb-2">No Recent Broadcasts</h3>
+            <h3 className="text-lg font-medium text-slate-400 mb-2">
+              No Recent Broadcasts
+            </h3>
             <p className="text-slate-500 text-sm">
               Share quick updates and alerts with your group
             </p>


### PR DESCRIPTION
## Summary
- add optional `recipients` to `BroadcastComposer` and `Broadcasts`
- dedupe user IDs in `handleNewBroadcast` before sending

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670c966268832a9f9cc498a37729ed