### PR TITLE
Add event segments fetch and broadcast composer

### DIFF
--- a/src/components/BroadcastComposer.tsx
+++ b/src/components/BroadcastComposer.tsx
@@ -1,20 +1,23 @@
 
 import React, { useState } from 'react';
-import { Send, MapPin, Clock } from 'lucide-react';
+import { Send, MapPin } from 'lucide-react';
 import { Button } from './ui/button';
+import type { EventSegment } from './events/eventSegments';
 
 interface BroadcastComposerProps {
   onSend: (broadcast: {
     message: string;
     location?: string;
     category: 'chill' | 'logistics' | 'urgent';
+    segmentId?: string;
   }) => void;
+  segments?: EventSegment[];
 }
-
-export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
+export const BroadcastComposer = ({ onSend, segments }: BroadcastComposerProps) => {
   const [message, setMessage] = useState('');
   const [location, setLocation] = useState('');
   const [category, setCategory] = useState<'chill' | 'logistics' | 'urgent'>('chill');
+  const [segmentId, setSegmentId] = useState('');
   const [showDetails, setShowDetails] = useState(false);
 
   const handleSend = () => {
@@ -23,13 +26,15 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
     onSend({
       message: message.trim(),
       location: location.trim() || undefined,
-      category
+      category,
+      segmentId: segmentId || undefined
     });
 
     // Reset form
     setMessage('');
     setLocation('');
     setCategory('chill');
+    setSegmentId('');
     setShowDetails(false);
   };
 
@@ -49,6 +54,21 @@ export const BroadcastComposer = ({ onSend }: BroadcastComposerProps) => {
           <Send size={16} className="text-white" />
         </div>
         <div className="flex-1">
+          {segments && segments.length > 0 && (
+            <select
+              value={segmentId}
+              onChange={(e) => setSegmentId(e.target.value)}
+              className="mb-3 w-full bg-slate-900/50 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none"
+            >
+              <option value="">All Participants</option>
+              {segments.map((seg) => (
+                <option key={seg.id} value={seg.id}>
+                  {seg.name}
+                  {seg.count ? ` (${seg.count})` : ''}
+                </option>
+              ))}
+            </select>
+          )}
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -56,6 +56,7 @@ export const Broadcasts = () => {
     message: string;
     location?: string;
     category: 'chill' | 'logistics' | 'urgent';
+    segmentId?: string;
   }) => {
     const broadcast: BroadcastData = {
       id: Date.now().toString(),

--- a/src/components/events/SegmentedBroadcastsSection.tsx
+++ b/src/components/events/SegmentedBroadcastsSection.tsx
@@ -1,8 +1,27 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Megaphone, Target, Send, Clock } from 'lucide-react';
+import { BroadcastComposer } from '../BroadcastComposer';
+import { fetchEventSegments, EventSegment } from './eventSegments';
 
 export const SegmentedBroadcastsSection = () => {
+  const [segments, setSegments] = useState<EventSegment[]>([]);
+
+  useEffect(() => {
+    fetchEventSegments()
+      .then(setSegments)
+      .catch((err) => console.error('Failed to load segments', err));
+  }, []);
+
+  const handleBroadcast = (broadcast: {
+    message: string;
+    location?: string;
+    category: 'chill' | 'logistics' | 'urgent';
+    segmentId?: string;
+  }) => {
+    console.log('New broadcast', broadcast);
+  };
+
   return (
     <div className="space-y-6">
       <h3 className="text-2xl font-bold text-white">Segmented Broadcast System</h3>
@@ -14,28 +33,25 @@ export const SegmentedBroadcastsSection = () => {
           Audience Segments
         </h4>
         <div className="space-y-4">
-          {[
-            { name: 'All Attendees', count: '847', criteria: 'Everyone registered' },
-            { name: 'VIP Guests', count: '67', criteria: 'VIP ticket holders' },
-            { name: 'Speakers & Panelists', count: '24', criteria: 'Speaker role assigned' },
-            { name: 'First-time Attendees', count: '312', criteria: 'New to event series' },
-            { name: 'Tech Industry', count: '445', criteria: 'Industry = Technology' },
-            { name: 'Local Attendees', count: '203', criteria: 'Within 50 miles of venue' }
-          ].map((segment) => (
-            <div key={segment.name} className="bg-white/5 rounded-lg p-4 border border-white/10">
+          {segments.map((segment) => (
+            <div key={segment.id} className="bg-white/5 rounded-lg p-4 border border-white/10">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-3">
                   <h5 className="text-white font-medium">{segment.name}</h5>
-                  <span className="bg-glass-orange/20 text-glass-orange px-2 py-1 rounded-full text-sm">
-                    {segment.count} people
-                  </span>
+                  {segment.count !== undefined && (
+                    <span className="bg-glass-orange/20 text-glass-orange px-2 py-1 rounded-full text-sm">
+                      {segment.count} people
+                    </span>
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <button className="text-glass-orange hover:text-glass-orange/80 text-sm">Edit</button>
                   <button className="text-blue-400 hover:text-blue-300 text-sm">Send Message</button>
                 </div>
               </div>
-              <p className="text-gray-400 text-sm">{segment.criteria}</p>
+              {segment.criteria && (
+                <p className="text-gray-400 text-sm">{segment.criteria}</p>
+              )}
             </div>
           ))}
           <button className="w-full bg-glass-orange/20 hover:bg-glass-orange/30 text-glass-orange border border-glass-orange/30 rounded-lg py-3 font-medium">
@@ -140,55 +156,7 @@ export const SegmentedBroadcastsSection = () => {
           <Megaphone size={20} />
           Compose New Broadcast
         </h4>
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-gray-300 mb-2">Select Audience</label>
-              <select className="w-full bg-gray-800/50 border border-gray-600 text-white rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-glass-orange/50">
-                <option>All Attendees (847 people)</option>
-                <option>VIP Guests (67 people)</option>
-                <option>Speakers & Panelists (24 people)</option>
-                <option>Tech Industry (445 people)</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-gray-300 mb-2">Delivery Method</label>
-              <select className="w-full bg-gray-800/50 border border-gray-600 text-white rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-glass-orange/50">
-                <option>Email + Push Notification</option>
-                <option>Email Only</option>
-                <option>Push Notification Only</option>
-                <option>In-App Message Only</option>
-              </select>
-            </div>
-          </div>
-          <div>
-            <label className="block text-sm text-gray-300 mb-2">Subject Line</label>
-            <input 
-              type="text" 
-              placeholder="Enter message subject..."
-              className="w-full bg-gray-800/50 border border-gray-600 text-white rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-glass-orange/50"
-            />
-          </div>
-          <div>
-            <label className="block text-sm text-gray-300 mb-2">Message Content</label>
-            <textarea 
-              rows={4}
-              placeholder="Write your message here..."
-              className="w-full bg-gray-800/50 border border-gray-600 text-white rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-glass-orange/50 resize-none"
-            />
-          </div>
-          <div className="flex gap-4">
-            <button className="bg-glass-orange hover:bg-glass-orange/80 text-white px-6 py-3 rounded-lg font-medium flex-1">
-              Send Now
-            </button>
-            <button className="bg-white/10 hover:bg-white/20 text-white px-6 py-3 rounded-lg font-medium">
-              Schedule Later
-            </button>
-            <button className="bg-gray-600 hover:bg-gray-700 text-white px-6 py-3 rounded-lg font-medium">
-              Save Draft
-            </button>
-          </div>
-        </div>
+        <BroadcastComposer onSend={handleBroadcast} segments={segments} />
       </div>
     </div>
   );

--- a/src/components/events/eventSegments.ts
+++ b/src/components/events/eventSegments.ts
@@ -1,0 +1,19 @@
+export interface EventSegment {
+  id: string;
+  name: string;
+  count?: number;
+  criteria?: string;
+}
+
+export const fetchEventSegments = async (): Promise<EventSegment[]> => {
+  const res = await fetch('/api/event/segments');
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Failed to fetch event segments');
+  }
+
+  const data = await res.json();
+  if (Array.isArray(data)) return data as EventSegment[];
+  if (Array.isArray(data.segments)) return data.segments as EventSegment[];
+  return [];
+};


### PR DESCRIPTION
## Summary
- add helper to fetch event segments from `/api/event/segments`
- extend `BroadcastComposer` to accept segments
- allow `Broadcasts` to send segments
- wire `SegmentedBroadcastsSection` to fetch segments and use `BroadcastComposer`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670c84c818832ab65b230ad8a936ac