### PR TITLE
Add recipient selection for AI messages

### DIFF
--- a/src/components/AiMessageComposer.tsx
+++ b/src/components/AiMessageComposer.tsx
@@ -3,18 +3,26 @@ import { OpenAIService } from '../services/OpenAIService';
 import { useMessages } from '../hooks/useMessages';
 import { Send } from 'lucide-react';
 
-export const AiMessageComposer = () => {
+interface Participant {
+  id: string;
+  name: string;
+}
+export const AiMessageComposer = ({ participants = [] }: { participants?: Participant[] }) => {
   const { addMessage } = useMessages();
   const [prompt, setPrompt] = useState('');
   const [tone, setTone] = useState<'friendly' | 'professional' | 'funny'>('friendly');
   const [isSending, setIsSending] = useState(false);
+  const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
 
   const send = async () => {
     if (!prompt.trim()) return;
     setIsSending(true);
     try {
       const response = await OpenAIService.queryOpenAI(prompt, { tone });
-      await addMessage(response);
+      await addMessage(response, undefined, undefined, {
+        type: 'individual',
+        userIds: selectedRecipients,
+      });
       setPrompt('');
     } catch (e) {
       console.error(e);
@@ -33,6 +41,22 @@ export const AiMessageComposer = () => {
         placeholder="Ask the AI to craft a message..."
       />
       <div className="flex items-center justify-between gap-2">
+        <select
+          multiple
+          value={selectedRecipients}
+          onChange={(e) =>
+            setSelectedRecipients(
+              Array.from(e.target.selectedOptions, (o) => o.value)
+            )
+          }
+          className="bg-slate-900 text-white border border-slate-700 rounded px-2 py-1"
+        >
+          {participants.map((p) => (
+            <option key={p.id} value={p.id} className="bg-slate-900">
+              {p.name}
+            </option>
+          ))}
+        </select>
         <select
           value={tone}
           onChange={(e) => setTone(e.target.value as any)}

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -75,7 +75,12 @@ export const useMessages = () => {
     return () => clearInterval(timer);
   }, []);
 
-  const addMessage = async (content: string, tripId?: string, tourId?: string) => {
+  const addMessage = async (
+    content: string,
+    tripId?: string,
+    tourId?: string,
+    recipients?: { type: 'individual' | 'all'; userIds?: string[] }
+  ) => {
     const priority = await OpenAIService.classifyPriority(content);
     const newMessage: Message = {
       id: Date.now().toString(),
@@ -87,7 +92,8 @@ export const useMessages = () => {
       isRead: true,
       tripId,
       tourId,
-      priority
+      priority,
+      recipients
     };
 
     setMessages(prev => [...prev, newMessage]);

--- a/src/pages/__tests__/AiMessageComposer.test.tsx
+++ b/src/pages/__tests__/AiMessageComposer.test.tsx
@@ -29,13 +29,18 @@ describe('AiMessageComposer', () => {
     });
     vi.mocked(OpenAIService.queryOpenAI).mockResolvedValue('response');
 
-    render(<AiMessageComposer />);
+    render(<AiMessageComposer participants={[{ id: '1', name: 'Test User' }]} />);
     const textarea = screen.getByPlaceholderText('Ask the AI to craft a message...') as HTMLTextAreaElement;
+    const recipientSelect = screen.getByRole('listbox');
+    fireEvent.change(recipientSelect, { target: { value: '1' } });
     fireEvent.change(textarea, { target: { value: 'hello' } });
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
 
     await waitFor(() => {
-      expect(addMessage).toHaveBeenCalledWith('response');
+      expect(addMessage).toHaveBeenCalledWith('response', undefined, undefined, {
+        type: 'individual',
+        userIds: ['1'],
+      });
     });
 
     expect(textarea.value).toBe('');

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -13,6 +13,10 @@ export interface Message {
   isRead: boolean;
   priority?: 'urgent' | 'reminder' | 'fyi';
   mentions?: string[];
+  recipients?: {
+    type: 'individual' | 'all';
+    userIds?: string[];
+  };
   threadId?: string;
   replyToId?: string;
 }


### PR DESCRIPTION
## Summary
- allow AI message composer to pick recipients and send to individuals
- track selected recipients in message state
- support new recipients field in message types and hook
- update unit test for new recipients logic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670c8f1824832a9780cafd6440ac22