### PR TITLE
Enable GetStream chat integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for local development
+STREAM_API_KEY=
+STREAM_API_SECRET=

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ environment variables:
   read and write data in your Supabase project.
 - `ELEVENLABS_API_KEY` – optional, enables speech generation in the
   `generate-audio-summary` function.
+- `STREAM_API_KEY` and `STREAM_API_SECRET` – credentials for the GetStream
+  chat service used by `/functions/getstream-token`.
 
 For local development, create a `supabase/.env.local` file containing these
 variables so they are loaded when running `supabase functions serve`.

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,96 +1,67 @@
-
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { Channel, MessageResponse } from 'stream-chat';
+import { useGetStream } from './useGetStream';
 import { Message, ScheduledMessage } from '../types/messaging';
 import { OpenAIService } from '../services/OpenAIService';
-import { proTripMockData } from '../data/proTripMockData';
+
+interface ChannelMap {
+  [tripId: string]: Channel;
+}
+
+interface MessageMap {
+  [tripId: string]: Message[];
+}
+
+const mapMessage = (msg: MessageResponse, tripId: string): Message => ({
+  id: msg.id,
+  content: msg.text || '',
+  senderId: msg.user?.id || '',
+  senderName: msg.user?.name || '',
+  senderAvatar: msg.user?.image,
+  timestamp: new Date(msg.created_at as string).toISOString(),
+  isRead: true,
+  tripId
+});
 
 export const useMessages = () => {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const { isReady, getTripChannel } = useGetStream();
+  const [channels, setChannels] = useState<ChannelMap>({});
+  const [messagesByTrip, setMessagesByTrip] = useState<MessageMap>({});
   const [scheduledMessages, setScheduledMessages] = useState<ScheduledMessage[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Generate dynamic mock messages based on trip data
-  const generateMockMessages = (tourId: string): Message[] => {
-    const tripData = proTripMockData[tourId];
-    if (!tripData) return [];
-
-    const participants = tripData.participants;
-    const baseMessages: Message[] = [
-      {
-        id: '1',
-        content: `Looking forward to ${tripData.title}! This is going to be amazing.`,
-        senderId: 'user-1',
-        senderName: participants[0]?.name || 'Team Lead',
-        senderAvatar: participants[0]?.avatar || 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face',
-        timestamp: '2024-01-15T10:30:00Z',
-        isRead: false,
-        tourId: tourId
-      },
-      {
-        id: '2',
-        content: `Just confirmed all arrangements for ${tripData.location}. Everything looks great!`,
-        senderId: 'user-2',
-        senderName: participants[1]?.name || 'Coordinator',
-        senderAvatar: participants[1]?.avatar || 'https://images.unsplash.com/photo-1494790108755-2616b612b47c?w=40&h=40&fit=crop&crop=face',
-        timestamp: '2024-01-15T11:15:00Z',
-        isRead: false,
-        tourId: tourId
-      },
-      {
-        id: '3',
-        content: `Team check-in: Is everyone ready for ${tripData.dateRange}?`,
-        senderId: 'user-3',
-        senderName: participants[2]?.name || 'Manager',
-        senderAvatar: participants[2]?.avatar || 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=40&h=40&fit=crop&crop=face',
-        timestamp: '2024-01-15T14:22:00Z',
-        isRead: false,
-        tourId: tourId
-      }
-    ];
-
-    return baseMessages;
-  };
-
-  const getMessagesForTour = (tourId: string): Message[] => {
-    return generateMockMessages(tourId);
+  const ensureChannel = async (tripId: string): Promise<Channel | null> => {
+    if (!isReady) return null;
+    if (channels[tripId]) return channels[tripId];
+    const channel = await getTripChannel(tripId);
+    if (!channel) return null;
+    await channel.watch();
+    setChannels(prev => ({ ...prev, [tripId]: channel }));
+    const initial = channel.state.messages.map(m => mapMessage(m, tripId));
+    setMessagesByTrip(prev => ({ ...prev, [tripId]: initial }));
+    channel.on('message.new', event => {
+      const msg = mapMessage(event.message, tripId);
+      setMessagesByTrip(prev => ({
+        ...prev,
+        [tripId]: [...(prev[tripId] || []), msg]
+      }));
+    });
+    return channel;
   };
 
   const getMessagesForTrip = (tripId: string): Message[] => {
-    return messages.filter(msg => msg.tripId === tripId);
+    ensureChannel(tripId);
+    return messagesByTrip[tripId] || [];
   };
 
-  useEffect(() => {
-    const timer = setInterval(() => {
-      const now = new Date();
-      setScheduledMessages(prev => {
-        const toSend = prev.filter(m => !m.isSent && new Date(m.sendAt) <= now);
-        if (toSend.length > 0) {
-          toSend.forEach(m => {
-            setMessages(ms => [...ms, { ...m, isSent: undefined }]);
-          });
-        }
-        return prev.map(m => (toSend.includes(m) ? { ...m, isSent: true } : m));
-      });
-    }, 60000);
-    return () => clearInterval(timer);
-  }, []);
+  const getMessagesForTour = (tourId: string): Message[] => getMessagesForTrip(tourId);
 
   const addMessage = async (content: string, tripId?: string, tourId?: string) => {
-    const priority = await OpenAIService.classifyPriority(content);
-    const newMessage: Message = {
-      id: Date.now().toString(),
-      content,
-      senderId: 'current-user',
-      senderName: 'You',
-      senderAvatar: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face',
-      timestamp: new Date().toISOString(),
-      isRead: true,
-      tripId,
-      tourId,
-      priority
-    };
-
-    setMessages(prev => [...prev, newMessage]);
+    const id = tripId || tourId;
+    if (!id) return;
+    const channel = await ensureChannel(id);
+    if (!channel) return;
+    await channel.sendMessage({ text: content });
   };
 
   const scheduleMessage = async (content: string, sendAt: Date, tripId?: string, tourId?: string) => {
@@ -98,13 +69,12 @@ export const useMessages = () => {
     try {
       await fetch('/api/message-scheduler', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           content,
           send_at: sendAt.toISOString(),
           trip_id: tripId,
+          tour_id: tourId,
           user_id: 'current-user',
           priority
         })
@@ -114,28 +84,26 @@ export const useMessages = () => {
     }
   };
 
-  const searchMessages = (query: string) => {
-    setSearchQuery(query);
-  };
+  const searchMessages = (query: string) => setSearchQuery(query);
 
-  const markAsRead = (messageId: string) => {
-    setMessages(prev => 
-      prev.map(msg => 
-        msg.id === messageId ? { ...msg, isRead: true } : msg
+  const markAsRead = (messageId: string, tripId?: string) => {
+    if (!tripId) return;
+    setMessagesByTrip(prev => ({
+      ...prev,
+      [tripId]: (prev[tripId] || []).map(m =>
+        m.id === messageId ? { ...m, isRead: true } : m
       )
-    );
+    }));
   };
 
-  const getTotalUnreadCount = (): number => {
-    return messages.filter(msg => !msg.isRead).length;
-  };
+  const getTotalUnreadCount = (): number =>
+    Object.values(messagesByTrip).flat().filter(m => !m.isRead).length;
 
-  const getTripUnreadCount = (tripId: string): number => {
-    return messages.filter(msg => msg.tripId === tripId && !msg.isRead).length;
-  };
+  const getTripUnreadCount = (tripId: string): number =>
+    (messagesByTrip[tripId] || []).filter(m => !m.isRead).length;
 
   return {
-    messages,
+    messages: Object.values(messagesByTrip).flat(),
     scheduledMessages,
     searchQuery,
     getMessagesForTour,

--- a/src/services/MessageService.ts
+++ b/src/services/MessageService.ts
@@ -1,4 +1,5 @@
 import { Message, ScheduledMessage } from '../types/messaging';
+import { getStreamService } from './getStreamService';
 
 export interface MessageTemplate {
   id: string;
@@ -37,6 +38,11 @@ export interface DailyDigest {
 
 export class MessageService {
   private static baseUrl = '/api';
+
+  static async sendMessage(tripId: string, text: string): Promise<void> {
+    const channel = await getStreamService.getOrCreateTripChannel(tripId);
+    await channel.sendMessage({ text });
+  }
 
   static async scheduleMessage(request: ScheduledMessageRequest): Promise<{ success: boolean; id?: string; error?: string }> {
     try {

--- a/supabase/migrations/20250723000002_add_channel_messages.sql
+++ b/supabase/migrations/20250723000002_add_channel_messages.sql
@@ -1,0 +1,23 @@
+-- Create channel_messages table for storing Stream chat history
+CREATE TABLE public.channel_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  channel_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  text TEXT,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+-- Indexes for faster lookups
+CREATE INDEX channel_messages_channel_id_idx ON public.channel_messages(channel_id);
+CREATE INDEX channel_messages_user_id_idx ON public.channel_messages(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE public.channel_messages ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to manage their own messages
+CREATE POLICY "Users manage own messages" ON public.channel_messages
+  FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create `channel_messages` table for persisting chat
- integrate GetStream in `useMessages` hook
- update demo chat to pull messages from GetStream
- expose new `MessageService.sendMessage`
- document `STREAM_API_*` vars and add sample env file

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c88d21c8832aa0bb17cf732d018c