### PR TITLE
Implement invite flow

### DIFF
--- a/src/components/InviteModal.tsx
+++ b/src/components/InviteModal.tsx
@@ -27,7 +27,7 @@ export const InviteModal = ({ isOpen, onClose, tripName, tripId }: InviteModalPr
     handleShare,
     handleEmailInvite,
     handleSMSInvite
-  } = useInviteLink({ isOpen, tripName, requireApproval, expireIn7Days });
+  } = useInviteLink({ isOpen, tripId, tripName, requireApproval, expireIn7Days });
 
   if (!isOpen) return null;
 

--- a/src/components/share/ShareTripModal.tsx
+++ b/src/components/share/ShareTripModal.tsx
@@ -33,11 +33,12 @@ export const ShareTripModal = ({ isOpen, onClose, trip }: ShareTripModalProps) =
     loading,
     handleCopyLink,
     handleShare
-  } = useInviteLink({ 
-    isOpen, 
-    tripName: trip.title, 
-    requireApproval: false, 
-    expireIn7Days: false 
+  } = useInviteLink({
+    isOpen,
+    tripId: String(trip.id),
+    tripName: trip.title,
+    requireApproval: false,
+    expireIn7Days: false
   });
 
   // Handle ESC key

--- a/src/pages/JoinTrip.tsx
+++ b/src/pages/JoinTrip.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from '../integrations/supabase/client';
+import { InviteService } from '../services/inviteService';
 import { useAuth } from '../hooks/useAuth';
 import { toast } from 'sonner';
 import { Loader2, Users, MapPin, Calendar } from 'lucide-react';
@@ -165,17 +166,7 @@ const JoinTrip = () => {
       }
 
       // Handle real invites
-      const { data, error } = await supabase.rpc('join_trip_via_invite', {
-        invite_token_param: token
-      });
-
-      if (error) {
-        console.error('Error joining trip:', error);
-        toast.error('Failed to join trip');
-        return;
-      }
-
-      const result = typeof data === 'string' ? JSON.parse(data) : data;
+      const result = await InviteService.acceptInvite(token);
 
       if (result.success) {
         toast.success('Successfully joined the trip!');

--- a/src/services/inviteService.ts
+++ b/src/services/inviteService.ts
@@ -1,0 +1,11 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export const InviteService = {
+  async acceptInvite(token: string) {
+    const { data, error } = await supabase.rpc('join_trip_via_invite', {
+      invite_token_param: token,
+    });
+    if (error) throw error;
+    return typeof data === 'string' ? JSON.parse(data) : data;
+  },
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -35,3 +35,6 @@ verify_jwt = false
 
 [functions.populate-search-index]
 verify_jwt = false
+
+[functions.create-invite]
+verify_jwt = true

--- a/supabase/functions/create-invite/index.ts
+++ b/supabase/functions/create-invite/index.ts
@@ -1,0 +1,86 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.3';
+import { corsHeaders } from '../_shared/cors.ts';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid authentication token' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { trip_id, require_approval = false, expire_in_days } = await req.json();
+
+    if (!trip_id) {
+      return new Response(
+        JSON.stringify({ error: 'trip_id is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: membership } = await supabase
+      .from('trip_members')
+      .select('id')
+      .eq('trip_id', trip_id)
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .single();
+
+    if (!membership) {
+      return new Response(
+        JSON.stringify({ error: 'User is not a member of this trip' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const inviteToken = crypto.randomUUID();
+    const expiresAt = expire_in_days
+      ? new Date(Date.now() + Number(expire_in_days) * 24 * 60 * 60 * 1000).toISOString()
+      : null;
+
+    const { error } = await supabase.from('trip_invites').insert({
+      trip_id,
+      invite_token: inviteToken,
+      created_by: user.id,
+      expires_at: expiresAt,
+      require_approval,
+    });
+
+    if (error) {
+      console.error('Error creating invite:', error);
+      throw error;
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, invite_token: inviteToken }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    console.error('Error in create-invite function:', err);
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `create-invite` edge function for generating invite tokens
- record config entry for the new function
- create `inviteService` to join trips via tokens
- generate invites via edge function in `useInviteLink`
- update InviteModal and ShareTripModal to pass the trip ID
- use InviteService when accepting an invite

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883cf99f534832a833f8d29d75803d2