### PR TITLE
Integrate booking providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,12 @@ For local development, create a `supabase/.env.local` file containing these
 variables so they are loaded when running `supabase functions serve`.
 When deploying, set the same variables using `supabase secrets set` so the
 deployed functions have access to them.
+
+### Additional API keys
+
+The travel booking features require credentials for the third‑party providers. Set the following variables in your environment:
+
+- `VITE_SKYSCANNER_API_KEY` – used for flight searches
+- `VITE_BOOKING_API_KEY` – used for hotel searches
+- `VITE_YELP_API_KEY` – used for restaurant recommendations
+- `VITE_UBER_API_KEY` – used for transportation estimates

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -881,6 +881,60 @@ export type Database = {
         }
         Relationships: []
       }
+      trip_bookings: {
+        Row: {
+          id: string
+          trip_id: string
+          user_id: string
+          booking_type: string
+          provider: string
+          external_booking_id: string | null
+          confirmation_number: string | null
+          booking_data: Json
+          booking_status: string | null
+          total_price: number | null
+          currency: string | null
+          booking_date: string | null
+          travel_date: string | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          trip_id: string
+          user_id: string
+          booking_type: string
+          provider: string
+          external_booking_id?: string | null
+          confirmation_number?: string | null
+          booking_data?: Json
+          booking_status?: string | null
+          total_price?: number | null
+          currency?: string | null
+          booking_date?: string | null
+          travel_date?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          trip_id?: string
+          user_id?: string
+          booking_type?: string
+          provider?: string
+          external_booking_id?: string | null
+          confirmation_number?: string | null
+          booking_data?: Json
+          booking_status?: string | null
+          total_price?: number | null
+          currency?: string | null
+          booking_date?: string | null
+          travel_date?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       trip_venue_ideas: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250725200000_add_trip_bookings_table.sql
+++ b/supabase/migrations/20250725200000_add_trip_bookings_table.sql
@@ -1,0 +1,40 @@
+-- Add table for storing travel reservations
+CREATE TABLE IF NOT EXISTS trip_bookings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trip_id UUID REFERENCES trips(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  booking_type TEXT NOT NULL CHECK (booking_type IN ('flight', 'hotel', 'restaurant', 'transportation')),
+  provider TEXT NOT NULL,
+  external_booking_id TEXT,
+  confirmation_number TEXT,
+  booking_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+  booking_status TEXT DEFAULT 'pending' CHECK (booking_status IN ('pending', 'confirmed', 'cancelled', 'completed')),
+  total_price DECIMAL(10,2),
+  currency TEXT DEFAULT 'USD',
+  booking_date TIMESTAMPTZ DEFAULT now(),
+  travel_date TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_trip_bookings_trip_id ON trip_bookings(trip_id);
+CREATE INDEX IF NOT EXISTS idx_trip_bookings_user_id ON trip_bookings(user_id);
+
+ALTER TABLE trip_bookings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view bookings for their trips" ON trip_bookings
+  FOR SELECT USING (user_id = auth.uid() OR trip_id IN (
+    SELECT id FROM trips WHERE user_id = auth.uid()
+  ));
+
+CREATE POLICY "Users can manage bookings for their trips" ON trip_bookings
+  FOR ALL USING (user_id = auth.uid() OR trip_id IN (
+    SELECT id FROM trips WHERE user_id = auth.uid()
+  ));
+
+CREATE POLICY "Service role can manage all trip bookings" ON trip_bookings
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE TRIGGER update_trip_bookings_updated_at
+  BEFORE UPDATE ON trip_bookings
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- connect to real provider APIs in travel booking service
- persist bookings via new `trip_bookings` table
- update Supabase types for new table
- document required provider API keys

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883cf99f8f8832aa854252517652d3c