### PR TITLE
Integrate Claude Code config

### DIFF
--- a/.claude-code/config.yaml
+++ b/.claude-code/config.yaml
@@ -1,0 +1,29 @@
+claude:
+  project: travel-platform
+  mcp:
+    fileSystem:
+      root: '.'
+      recursive: true
+      fileTypes:
+        - ts
+        - tsx
+        - edge-functions
+    database:
+      provider: supabase
+      connection: env:SUPABASE_URL
+      realtime: true
+      securityContext: hardened
+    webSearch:
+      enable: true
+      sources:
+        - travel-api
+        - location-info
+  workflows:
+    codeReview: true
+    securityAudit: true
+    performance: true
+    architecture: true
+  mobile:
+    framework: capacitor
+  chat:
+    provider: getstream

--- a/.claude-code/mcp.yaml
+++ b/.claude-code/mcp.yaml
@@ -1,0 +1,21 @@
+fileSystem:
+  enabled: true
+  recursive: true
+  include:
+    - src
+    - supabase/functions
+    - supabase/migrations
+  fileTypes:
+    ts: true
+    tsx: true
+    js: true
+    jsx: true
+supabase:
+  projectId: yiitqkjrbskxumriujrh
+  realtime: true
+  securityContext: hardened
+webSearch:
+  enable: true
+  apis:
+    - travel
+    - venues

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ environment variables:
 - `STREAM_API_KEY` and `STREAM_API_SECRET` – credentials for the GetStream
   chat service used by `/functions/getstream-token`.
 
-For local development, create a `supabase/.env.local` file containing these
 variables so they are loaded when running `supabase functions serve`.
 When deploying, set the same variables using `supabase secrets set` so the
 deployed functions have access to them.
+
+## Claude Code
+
+Run `npm run claude` to launch Claude Code for advanced code analysis and MCP integration. See [docs/claude-code.md](docs/claude-code.md) for setup details.

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,36 @@
+# Claude Code Integration
+
+This project uses **Claude Code** for local code analysis and MCP features. The CLI is added as a development dependency and provides commands for code review, security audits and performance checks.
+
+## Installation
+
+1. Install the CLI globally (optional):
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+2. Install project dependencies:
+
+```bash
+npm install
+```
+
+3. Run initialization if needed:
+
+```bash
+npx claude init
+```
+
+## Usage
+
+Convenience scripts are available:
+
+```bash
+npm run claude            # Launch interactive Claude Code
+npm run claude:analyze    # Analyze the codebase
+npm run claude:security   # Run security audit
+npm run claude:review     # Perform a full review
+```
+
+Configuration lives in `.claude-code/` and includes MCP settings for Supabase, Capacitor, and GetStream chat integrations.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "claude": "claude",
+    "claude:analyze": "claude analyze",
+    "claude:security": "claude security",
+    "claude:review": "claude review"
   },
   "dependencies": {
     "@11labs/react": "^0.1.4",
@@ -99,6 +103,7 @@
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
+    "@anthropic-ai/claude-code": "^0.4.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",


### PR DESCRIPTION
## Summary
- add Claude Code dev dependency and commands
- document usage in README and separate guide
- configure MCP settings for the travel platform

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68899b387014832aab87ee1901dd3521