### PR TITLE
Fix layout issues in mobile tabs and chat composer

### DIFF
--- a/src/components/AIConciergeChat.tsx
+++ b/src/components/AIConciergeChat.tsx
@@ -2029,12 +2029,12 @@ export const AIConciergeChat = ({
 
         {/* Input area — sticky bottom with inline voice banner above input */}
         <div
-          className="chat-composer sticky bottom-0 z-10 bg-black/30 px-3 pt-2 flex-shrink-0"
+          className="chat-composer z-10 bg-black/30 px-3 pt-2 flex-shrink-0"
           style={{ paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 8px)' }}
         >
           {/* End session button — aligned above dictation button on same vertical axis */}
           {isLiveSessionActive && (
-            <div className="mb-2">
+            <div className="mb-2 w-11">
               <button
                 type="button"
                 onClick={() => void handleEndLiveSession()}

--- a/src/components/mobile/MobileTripTabs.tsx
+++ b/src/components/mobile/MobileTripTabs.tsx
@@ -605,9 +605,9 @@ export const MobileTripTabs = ({
               >
                 {/* ⚡ Per-tab error boundary: errors stay on failing tab, no bounce-back */}
                 <div
-                  className={
-                    showEventDisabledState ? 'opacity-50 pointer-events-none select-none' : ''
-                  }
+                  className={`flex-1 min-h-0 flex flex-col overflow-hidden${
+                    showEventDisabledState ? ' opacity-50 pointer-events-none select-none' : ''
+                  }`}
                 >
                   <Suspense fallback={getSkeletonForTab(tab.id)}>
                     <FeatureErrorBoundary featureName={tab.label}>


### PR DESCRIPTION
## Summary

Fixes layout and overflow issues in the mobile trip tabs component and AI concierge chat composer. Adds missing flexbox constraints to prevent content overflow and removes conflicting sticky positioning that was causing layout problems.

## Changes

- **MobileTripTabs**: Added `flex-1 min-h-0 flex flex-col overflow-hidden` classes to the tab content wrapper to properly constrain flex children and prevent overflow issues
- **AIConciergeChat**: 
  - Removed `sticky bottom-0` classes from chat composer that were causing layout conflicts
  - Added `w-11` width constraint to the end session button container for proper alignment

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Refactor (no functional change)
- [ ] Chore (dependency update, config change, docs, etc.)

## Deploy Impact

- [x] **None of the above** — code-only change

## Testing

Visual inspection of mobile layouts in trip tabs and chat composer. Existing tests pass.

## Risk

Low risk. These are CSS-only changes to fix layout issues without altering component behavior or data flow.

## Rollback Plan

Revert the commit to restore previous styling.

https://claude.ai/code/session_01JsfYRX3W8EFsCMoZh7fHHw