### PR TITLE
feat: native bridge adapter for Expo WebView

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -307,8 +307,20 @@ export const AuthModal = ({ isOpen, onClose, initialMode, hideClose }: AuthModal
   );
 
   return (
-    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[100] flex items-end tablet:items-center landscape:items-center justify-center p-0 tablet:p-4 landscape:p-4 animate-fade-in">
-      <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-t-3xl tablet:rounded-3xl landscape:rounded-3xl p-6 tablet:p-8 max-w-md w-full safe-bottom animate-slide-in-bottom tablet:animate-scale-in max-h-[90dvh] overflow-y-auto">
+    <div
+      className={
+        hideClose
+          ? 'fixed inset-0 z-[100] flex items-center justify-center bg-background'
+          : 'fixed inset-0 bg-black/80 backdrop-blur-sm z-[100] flex items-end tablet:items-center landscape:items-center justify-center p-0 tablet:p-4 landscape:p-4 animate-fade-in'
+      }
+    >
+      <div
+        className={
+          hideClose
+            ? 'w-full h-full flex flex-col justify-center p-6 max-w-md mx-auto'
+            : 'bg-white/10 backdrop-blur-md border border-white/20 rounded-t-3xl tablet:rounded-3xl landscape:rounded-3xl p-6 tablet:p-8 max-w-md w-full safe-bottom animate-slide-in-bottom tablet:animate-scale-in max-h-[90dvh] overflow-y-auto'
+        }
+      >
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold text-white">
             {mode === 'forgot'

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -11,9 +11,11 @@ interface AuthModalProps {
    * Defaults to 'signin' to preserve existing behavior.
    */
   initialMode?: 'signin' | 'signup';
+  /** When true, hides the close button (used in native app where auth is required). */
+  hideClose?: boolean;
 }
 
-export const AuthModal = ({ isOpen, onClose, initialMode }: AuthModalProps) => {
+export const AuthModal = ({ isOpen, onClose, initialMode, hideClose }: AuthModalProps) => {
   const { signIn, signInWithGoogle, signInWithApple, signUp, resetPassword, isLoading, user } =
     useAuth();
   const [googleLoading, setGoogleLoading] = useState(false);
@@ -315,9 +317,11 @@ export const AuthModal = ({ isOpen, onClose, initialMode }: AuthModalProps) => {
                 ? 'Create Account'
                 : 'Welcome Back'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
-            <X size={24} />
-          </button>
+          {!hideClose && (
+            <button onClick={onClose} className="text-gray-400 hover:text-white">
+              <X size={24} />
+            </button>
+          )}
         </div>
 
         {success && (

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -18,6 +18,7 @@ import { useNotificationRealtimeStore } from '@/store/notificationRealtimeStore'
 import { conciergeCacheService } from '@/services/conciergeCacheService';
 import { isSessionTokenValid } from '@/utils/tokenValidation';
 import { authDebug } from '@/utils/authDebug';
+import { signalReady } from '@/native/bridge';
 import { telemetry } from '@/telemetry/service';
 import { toast } from '@/hooks/use-toast';
 import { logAuthEvent } from '@/utils/authTelemetry';
@@ -120,6 +121,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const isLoadingRef = useRef(true);
+  const hasSignaledReady = useRef(false);
+
+  // Signal the native shell that auth hydration is complete.
+  // This is a fire-and-forget postMessage — no auth state is affected.
+  useEffect(() => {
+    if (!isLoading && !hasSignaledReady.current) {
+      hasSignaledReady.current = true;
+      signalReady();
+    }
+  }, [isLoading]);
 
   /**
    * App-preview mode should behave like "full demo access" even when there is no real auth session.

--- a/src/native/bridge.ts
+++ b/src/native/bridge.ts
@@ -1,0 +1,103 @@
+/**
+ * Native Bridge Adapter
+ *
+ * Detects the native runtime (Capacitor, Expo WebView, or plain browser)
+ * and provides helpers for communicating with the Expo native shell.
+ *
+ * The Expo shell injects `window.ChravelNative` before page load and
+ * listens for messages via `window.ReactNativeWebView.postMessage()`.
+ */
+
+export type NativeRuntime = 'capacitor' | 'expo-webview' | 'web';
+
+interface ChravelNativeGlobal {
+  platform: string;
+  isNative: boolean;
+  version: string;
+}
+
+interface ReactNativeWebViewGlobal {
+  postMessage: (message: string) => void;
+}
+
+declare global {
+  interface Window {
+    ChravelNative?: ChravelNativeGlobal;
+    ReactNativeWebView?: ReactNativeWebViewGlobal;
+  }
+}
+
+/**
+ * Detect which native runtime the web app is running inside.
+ */
+export function getNativeRuntime(): NativeRuntime {
+  if (typeof window === 'undefined') return 'web';
+
+  // Check Expo WebView first — it's more specific.
+  if (window.ChravelNative?.isNative) return 'expo-webview';
+
+  // Check Capacitor.
+  try {
+    // Dynamic import check to avoid bundling issues.
+    const cap = (window as Record<string, unknown>).Capacitor as
+      | { isNativePlatform?: () => boolean }
+      | undefined;
+    if (cap?.isNativePlatform?.()) return 'capacitor';
+  } catch {
+    // Capacitor not available.
+  }
+
+  return 'web';
+}
+
+/**
+ * Returns true if running inside any native shell (Capacitor or Expo).
+ */
+export function isNativeApp(): boolean {
+  return getNativeRuntime() !== 'web';
+}
+
+/**
+ * Returns true if running inside the Expo WebView shell.
+ */
+export function isExpoWebView(): boolean {
+  return getNativeRuntime() === 'expo-webview';
+}
+
+/**
+ * Send a typed message to the Expo native shell.
+ * No-ops if not running inside the Expo WebView.
+ */
+export function postToNative(message: Record<string, unknown>): void {
+  if (window.ReactNativeWebView?.postMessage) {
+    window.ReactNativeWebView.postMessage(JSON.stringify(message));
+  }
+}
+
+/**
+ * Listen for a custom event dispatched by the Expo native shell.
+ * Returns an unsubscribe function.
+ *
+ * The native shell sends events via:
+ *   webView.injectJavaScript(`window.dispatchEvent(new CustomEvent('name', { detail }))`)
+ */
+export function onNativeEvent<T = unknown>(
+  eventName: string,
+  callback: (detail: T) => void,
+): () => void {
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<T>).detail;
+    callback(detail);
+  };
+
+  window.addEventListener(eventName, handler);
+  return () => window.removeEventListener(eventName, handler);
+}
+
+/**
+ * Signal to the Expo native shell that the web app is ready.
+ * Call after auth hydration completes.
+ */
+export function signalReady(): void {
+  postToNative({ type: 'ready' });
+}

--- a/src/native/haptics.ts
+++ b/src/native/haptics.ts
@@ -8,6 +8,7 @@
 
 import { Capacitor } from '@capacitor/core';
 import { Haptics, ImpactStyle, NotificationType } from '@capacitor/haptics';
+import { getNativeRuntime, postToNative } from './bridge';
 
 /**
  * Returns true only when running inside a Capacitor native shell AND the
@@ -17,8 +18,16 @@ export function isNativeHaptics(): boolean {
   return Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('Haptics');
 }
 
-async function safeRun(fn: () => Promise<void>): Promise<void> {
-  // Hard gate: never even attempt haptics on web.
+async function safeRun(fn: () => Promise<void>, bridgeStyle?: string): Promise<void> {
+  const runtime = getNativeRuntime();
+
+  // Expo WebView: send haptic request via bridge.
+  if (runtime === 'expo-webview' && bridgeStyle) {
+    postToNative({ type: 'haptic', style: bridgeStyle });
+    return;
+  }
+
+  // Capacitor: use native plugin.
   if (!isNativeHaptics()) return;
 
   try {
@@ -32,27 +41,27 @@ async function safeRun(fn: () => Promise<void>): Promise<void> {
 }
 
 export async function light(): Promise<void> {
-  await safeRun(() => Haptics.impact({ style: ImpactStyle.Light }));
+  await safeRun(() => Haptics.impact({ style: ImpactStyle.Light }), 'light');
 }
 
 export async function medium(): Promise<void> {
-  await safeRun(() => Haptics.impact({ style: ImpactStyle.Medium }));
+  await safeRun(() => Haptics.impact({ style: ImpactStyle.Medium }), 'medium');
 }
 
 export async function heavy(): Promise<void> {
-  await safeRun(() => Haptics.impact({ style: ImpactStyle.Heavy }));
+  await safeRun(() => Haptics.impact({ style: ImpactStyle.Heavy }), 'heavy');
 }
 
 export async function success(): Promise<void> {
-  await safeRun(() => Haptics.notification({ type: NotificationType.Success }));
+  await safeRun(() => Haptics.notification({ type: NotificationType.Success }), 'success');
 }
 
 export async function warning(): Promise<void> {
-  await safeRun(() => Haptics.notification({ type: NotificationType.Warning }));
+  await safeRun(() => Haptics.notification({ type: NotificationType.Warning }), 'warning');
 }
 
 export async function error(): Promise<void> {
-  await safeRun(() => Haptics.notification({ type: NotificationType.Error }));
+  await safeRun(() => Haptics.notification({ type: NotificationType.Error }), 'error');
 }
 
 /**

--- a/src/native/push.ts
+++ b/src/native/push.ts
@@ -10,6 +10,7 @@ import {
   ActionPerformed,
   PushNotificationSchema,
 } from '@capacitor/push-notifications';
+import { getNativeRuntime, postToNative, onNativeEvent } from './bridge';
 
 // Typed payload format for Chravel notifications
 export interface ChravelPushPayload {
@@ -35,10 +36,12 @@ export interface PushNotificationResult {
 }
 
 /**
- * Check if native push is available
- * Guards all native calls to prevent web crashes
+ * Check if native push is available (Capacitor or Expo WebView).
+ * Guards all native calls to prevent web crashes.
  */
 export function isNativePush(): boolean {
+  const runtime = getNativeRuntime();
+  if (runtime === 'expo-webview') return true;
   return Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('PushNotifications');
 }
 
@@ -96,6 +99,29 @@ export async function checkPermissions(): Promise<PermissionResult> {
 export async function register(): Promise<PushNotificationResult> {
   if (!isNativePush()) {
     return { token: null, error: 'Not native platform' };
+  }
+
+  // Expo WebView: request token via bridge and wait for response.
+  if (getNativeRuntime() === 'expo-webview') {
+    return new Promise(resolve => {
+      const TIMEOUT_MS = 15_000;
+
+      const unsub = onNativeEvent<{ token: string | null; error: string | null }>(
+        'chravel:push-token',
+        detail => {
+          clearTimeout(timeoutId);
+          unsub();
+          resolve({ token: detail.token, error: detail.error ?? undefined });
+        },
+      );
+
+      const timeoutId = setTimeout(() => {
+        unsub();
+        resolve({ token: null, error: 'Registration timed out' });
+      }, TIMEOUT_MS);
+
+      postToNative({ type: 'push:register' });
+    });
   }
 
   // 15s timeout prevents the app from hanging if iOS never fires

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -33,6 +33,8 @@ const AuthPage = () => {
     return raw === 'signup' ? 'signup' : 'signin';
   }, [searchParams]);
 
+  const isNative = searchParams.get('native') === 'true';
+
   // Restore invite context from query param into localStorage
   // This ensures the invite code survives OAuth redirects that may clear localStorage
   useEffect(() => {
@@ -64,6 +66,7 @@ const AuthPage = () => {
       <AuthModal
         isOpen={true}
         initialMode={mode}
+        hideClose={isNative}
         onClose={() => navigate(returnTo, { replace: true })}
       />
     </div>


### PR DESCRIPTION
## Summary

Adds a bridge adapter so the web app can communicate with the Expo native shell when running inside the WebView wrapper.

**`src/native/bridge.ts`** (new)
- `getNativeRuntime()` — detects Capacitor, Expo WebView, or browser
- `postToNative()` — sends typed messages to Expo shell via `postMessage`
- `onNativeEvent()` — listens for events injected by the native shell
- `signalReady()` — tells the native shell auth hydration is complete

**`src/native/haptics.ts`** (updated)
- Expo WebView path: sends `{ type: "haptic", style }` via bridge
- Capacitor path: unchanged

**`src/native/push.ts`** (updated)
- Expo WebView path: sends `{ type: "push:register" }` and listens for `chravel:push-token` response
- Capacitor path: unchanged

**`src/hooks/useAuth.tsx`** (updated)
- Fires `signalReady()` once when `isLoading` transitions to `false`
- Fire-and-forget postMessage — no auth state affected, no-op on web