### PR TITLE
fix: set Apple Team ID in AASA for universal links

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "details": [
       {
         "appIDs": [
-          "TEAM_ID.com.chravel.app"
+          "2T6WY43H3X.com.chravel.app"
         ],
         "components": [
           {
@@ -23,6 +23,26 @@
             "comment": "OAuth callback"
           },
           {
+            "/": "/tour/*",
+            "comment": "Pro tour links"
+          },
+          {
+            "/": "/invite/*",
+            "comment": "Invite token links"
+          },
+          {
+            "/": "/share/*",
+            "comment": "Shared content links"
+          },
+          {
+            "/": "/profile/*",
+            "comment": "User profile links"
+          },
+          {
+            "/": "/organization/*",
+            "comment": "Organization links"
+          },
+          {
             "/": "/settings/*",
             "comment": "Deep link to settings"
           }
@@ -32,7 +52,7 @@
   },
   "webcredentials": {
     "apps": [
-      "TEAM_ID.com.chravel.app"
+      "2T6WY43H3X.com.chravel.app"
     ]
   }
 }

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -307,8 +307,20 @@ export const AuthModal = ({ isOpen, onClose, initialMode, hideClose }: AuthModal
   );
 
   return (
-    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[100] flex items-end tablet:items-center landscape:items-center justify-center p-0 tablet:p-4 landscape:p-4 animate-fade-in">
-      <div className="bg-white/10 backdrop-blur-md border border-white/20 rounded-t-3xl tablet:rounded-3xl landscape:rounded-3xl p-6 tablet:p-8 max-w-md w-full safe-bottom animate-slide-in-bottom tablet:animate-scale-in max-h-[90dvh] overflow-y-auto">
+    <div
+      className={
+        hideClose
+          ? 'fixed inset-0 z-[100] flex items-center justify-center bg-background'
+          : 'fixed inset-0 bg-black/80 backdrop-blur-sm z-[100] flex items-end tablet:items-center landscape:items-center justify-center p-0 tablet:p-4 landscape:p-4 animate-fade-in'
+      }
+    >
+      <div
+        className={
+          hideClose
+            ? 'w-full h-full flex flex-col justify-center p-6 max-w-md mx-auto'
+            : 'bg-white/10 backdrop-blur-md border border-white/20 rounded-t-3xl tablet:rounded-3xl landscape:rounded-3xl p-6 tablet:p-8 max-w-md w-full safe-bottom animate-slide-in-bottom tablet:animate-scale-in max-h-[90dvh] overflow-y-auto'
+        }
+      >
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold text-white">
             {mode === 'forgot'

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -11,9 +11,11 @@ interface AuthModalProps {
    * Defaults to 'signin' to preserve existing behavior.
    */
   initialMode?: 'signin' | 'signup';
+  /** When true, hides the close button (used in native app where auth is required). */
+  hideClose?: boolean;
 }
 
-export const AuthModal = ({ isOpen, onClose, initialMode }: AuthModalProps) => {
+export const AuthModal = ({ isOpen, onClose, initialMode, hideClose }: AuthModalProps) => {
   const { signIn, signInWithGoogle, signInWithApple, signUp, resetPassword, isLoading, user } =
     useAuth();
   const [googleLoading, setGoogleLoading] = useState(false);
@@ -315,9 +317,11 @@ export const AuthModal = ({ isOpen, onClose, initialMode }: AuthModalProps) => {
                 ? 'Create Account'
                 : 'Welcome Back'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-white">
-            <X size={24} />
-          </button>
+          {!hideClose && (
+            <button onClick={onClose} className="text-gray-400 hover:text-white">
+              <X size={24} />
+            </button>
+          )}
         </div>
 
         {success && (

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -33,6 +33,8 @@ const AuthPage = () => {
     return raw === 'signup' ? 'signup' : 'signin';
   }, [searchParams]);
 
+  const isNative = searchParams.get('native') === 'true';
+
   // Restore invite context from query param into localStorage
   // This ensures the invite code survives OAuth redirects that may clear localStorage
   useEffect(() => {
@@ -64,6 +66,7 @@ const AuthPage = () => {
       <AuthModal
         isOpen={true}
         initialMode={mode}
+        hideClose={isNative}
         onClose={() => navigate(returnTo, { replace: true })}
       />
     </div>


### PR DESCRIPTION
## Summary

Updates the apple-app-site-association file with the real Apple Team ID (2T6WY43H3X) and adds missing deep link route patterns.

**Routes added:** /tour/*, /invite/*, /share/*, /profile/*, /organization/*

Once deployed, universal links from chravel.app will open the native app instead of the browser.